### PR TITLE
Scaffold update to unrestrict category from diagnostic request groups

### DIFF
--- a/input/fsh/erequesting/eRequestingRadiologyRequestGroup.fsh
+++ b/input/fsh/erequesting/eRequestingRadiologyRequestGroup.fsh
@@ -7,5 +7,3 @@ Description: "A group of radiology requests as would be captured in a radiology 
 * basedOn 0..0
 
 * code 0..0
-
-* category 0..0


### PR DESCRIPTION
Remove constraint on having category in Pathology and Radiology request groups.  No, I have no idea why I put a constraint on it.