### PR TITLE
Add AU Variance Statement

### DIFF
--- a/input/includes/menu.xml
+++ b/input/includes/menu.xml
@@ -30,6 +30,9 @@
         <a href="relationship.html">Relationship with other HL7 AU FHIR IGs</a>
       </li>
       <li>
+        <a href="variance.html">AU Variance Statement</a>
+      </li>
+      <li>
         <a href="erequesting-future.html">Future of AU eRequesting </a>
       </li>
     </ul>

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -26,6 +26,7 @@ This guide is divided into several pages which are listed at the top of each pag
 - [Guidance](guidance.html): This is a placeholder for when content becomes available.
   - [AU eRequesting data for interoperability](auereqdi.html): This is a placeholder for when content becomes available.
   - [Relationship with other HL7 AU FHIR IGs](relationship.html): This is a placeholder for when content becomes available.
+  - [AU Variance Statement](variance.html): This page documents variance from AU Base and AU Core.
   - [Future of AU eRequesting](erequesting-future.html): This is a placeholder for when content becomes available.
 - [Use Cases](use-cases.html): This page describes the use cases in scope of eRequesting R1. 
 - [FHIR Artefacts](artifacts.html): This is a placeholder for when content becomes available.

--- a/input/pagecontent/variance.md
+++ b/input/pagecontent/variance.md
@@ -1,0 +1,17 @@
+### Variance from AU Base
+This implementation guide has no variance (i.e. fully compliant) from AU Base FHIR Implementation Guide version 4.2.1-ci-build ([current](https://build.fhir.org/ig/hl7au/au-fhir-base/)).
+
+#### Additionally Profiled Resources
+This implementation guide profiles the following resources that are not profiled in AU Base:
+
+- ServiceRequest
+  - [AU eRequesting ServiceRequest](https://build.fhir.org/ig/hl7au/au-fhir-erequesting/StructureDefinition-au-erequesting-servicerequest.html)
+
+### Variance from AU Core
+This implementation guide has no variance (i.e. fully compliant) from AU Core FHIR Implementation Guide version 0.4.0-ci-build ([current](https://build.fhir.org/ig/hl7au/au-fhir-core/)).
+
+#### Additionally Profiled Resources
+This implementation guide profiles the following resources that are not profiled in AU Core:
+
+- ServiceRequest
+  - [AU eRequesting ServiceRequest](https://build.fhir.org/ig/hl7au/au-fhir-erequesting/StructureDefinition-au-erequesting-servicerequest.html)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -47,6 +47,8 @@ pages:
       title: Future of AU eRequesting
     relationship.md: 
       title: Relationship with other HL7 AU FHIR IGs
+    variance.md:
+      title: AU Variance Statement
     auereqdi.md:
       title: AU eRequesting Data for Interoperability
   use-cases.md:


### PR DESCRIPTION
All AU realm FHIR IGs have agreed to include a variance from AU Core and AU Base, as documented in the [** DRAFT ** Process: AU Realm FHIR IG Variance Requirements. ](https://confluence.hl7.org/display/HA/**+DRAFT+**+Process%3A++AU+Realm+FHIR+IG+Variance+Requirements).

This PR adds an AU Variance Statement page to document the variance as described in the above link.