### PR TITLE
AU eRequesting ServiceRequest - update for the latest Wave 1 and Wave 2 agreements 

### DIFF
--- a/input/fsh/au-erequesting-servicerequest.fsh
+++ b/input/fsh/au-erequesting-servicerequest.fsh
@@ -52,9 +52,9 @@ Description: "This profile defines a service request structure to represent a re
 Invariant: au-erequesting-srr-00
 Description: "Date must include at least year, month, and day"
 Severity: #error
-Expression: "TBD"
+Expression: "authoredOn.exists()"
 
 Invariant: au-erequesting-srr-01
 Description: "Category shall be one of SNOMED CT 108252007 Laboratory procedure or SNOMED CT 363679005 Imaging"
 Severity: #error
-Expression: "TBD"
+Expression: "category.exists()"

--- a/input/fsh/au-erequesting-servicerequest.fsh
+++ b/input/fsh/au-erequesting-servicerequest.fsh
@@ -15,6 +15,7 @@ Description: "This profile defines a service request structure to represent a re
 
 
 * identifier MS 
+
 * status MS
 
 * intent 1..1
@@ -28,6 +29,7 @@ Description: "This profile defines a service request structure to represent a re
 
 * authoredOn 1..1
 * authoredOn MS 
+* authoredOn obeys au-erequesting-srr-00
 
 * requester 1..1
 * requester MS
@@ -37,5 +39,22 @@ Description: "This profile defines a service request structure to represent a re
 
 * category 1..*
 * category MS
+* category obeys au-erequesting-srr-01
 
+* note MS
 
+* insurance MS
+
+* encounter MS
+
+* reasonCode MS
+
+Invariant: au-erequesting-srr-00
+Description: "Date must include at least year, month, and day"
+Severity: #error
+Expression: "TBD"
+
+Invariant: au-erequesting-srr-01
+Description: "Category shall be one of SNOMED CT 108252007 Laboratory procedure or SNOMED CT 363679005 Imaging"
+Severity: #error
+Expression: "TBD"


### PR DESCRIPTION
This PR implements the agreements from the 2024-06-20 eRequesting TDG call: https://confluence.hl7.org/pages/viewpage.action?pageId=248710659

Changes: 
- Add MS flag to the following elements:
  - ServiceRequest.note 0..*
  - ServiceRequest.insurance 0..*
  - ServiceRequest.encounter 0..1
  - ServiceRequest.reasonCode 0..*
- Add 'placeholder' invariants for the Wave 2 agreements related to ServiceRequest.authoredOn and ServiceRequest.category, noting that the expressions are currently TBD.