### PR TITLE
FHIR IG menu items and Downloads page changes

### DIFF
--- a/input/includes/menu.xml
+++ b/input/includes/menu.xml
@@ -49,9 +49,6 @@
         <a href="profiles-and-extensions.html">Profiles and Extensions</a>
       </li>
       <li>
-        <a href="search-parameters-and-operations.md">Search Parameters and Operations</a>
-      </li>
-      <li>
         <a href="terminology.html">Terminology</a>
       </li>
         <!-- <li>

--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -37,4 +37,4 @@ The following link to the ImplementationGuide resource defines the technical det
 
 - [XML](ImplementationGuide-hl7.fhir.au.core.xml) 
 - [JSON](ImplementationGuide-hl7.fhir.au.core.json)
-- [TTL](ImplementationGuide-hl7.fhir.au.core.ttl) -->
+- [TTL](ImplementationGuide-hl7.fhir.au.core.ttl)

--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -9,16 +9,16 @@ It is not recommended to view locally without hosting, but you can extract the f
 
 ### Package file
 
-<!-- The following package file includes an NPM package file used by many of the FHIR tools.  It contains all the value sets, profiles, extensions, list of pages and urls in the IG, etc defined as part of this version of the Implementation Guides. This file should be the first choice whenever generating any implementation artefacts since it contains all of the rules about what makes the profiles valid. Implementers will still need to be familiar with the content of the specification and profiles that apply in order to make a conformant implementation:
+The following package file includes an NPM package file used by many of the FHIR tools.  It contains all the value sets, profiles, extensions, list of pages and urls in the IG, etc defined as part of this version of the Implementation Guides. This file should be the first choice whenever generating any implementation artefacts since it contains all of the rules about what makes the profiles valid. Implementers will still need to be familiar with the content of the specification and profiles that apply in order to make a conformant implementation:
 
 - [R4 Package](package.tgz){::download="true"}
 - [R4B Package](package.r4b.tgz){::download="true"}
 
-See the overview on [validating FHIR profiles and resources](http://hl7.org/fhir/R4/validation.html) for more information about validating profiles and how to use these artefacts. -->
+See the overview on [validating FHIR profiles and resources](http://hl7.org/fhir/R4/validation.html) for more information about validating profiles and how to use these artefacts.
 
 ### Examples 
 
-<!-- All examples included in this implementation guide are available for download:
+All examples included in this implementation guide are available for download:
 
 - [XML](examples.xml.zip)
 - [JSON](examples.json.zip)
@@ -26,14 +26,14 @@ See the overview on [validating FHIR profiles and resources](http://hl7.org/fhir
 
 ### Consolidated CSV and Excel file representations of profiles 
 
-<!-- All the profile information for the {{site.data.fhir.ig.title}} in a single CSV or Excel file, which may be helpful to testers and analysts to review element properties across profiles in a single table:
+All the profile information for the {{site.data.fhir.ig.title}} in a single CSV or Excel file, which may be helpful to testers and analysts to review element properties across profiles in a single table:
 
 - [CSV(compressed folder)](csvs.zip)
 - [Excel(compressed folder)](excels.zip)
- -->
+
 ### Implementation Guide Details
 
-<!-- The following link to the ImplementationGuide resource defines the technical details of this publication, including dependencies and publishing parameters:
+The following link to the ImplementationGuide resource defines the technical details of this publication, including dependencies and publishing parameters:
 
 - [XML](ImplementationGuide-hl7.fhir.au.core.xml) 
 - [JSON](ImplementationGuide-hl7.fhir.au.core.json)

--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -22,7 +22,7 @@ All examples included in this implementation guide are available for download:
 
 - [XML](examples.xml.zip)
 - [JSON](examples.json.zip)
-- [TTL](examples.ttl.zip) -->
+- [TTL](examples.ttl.zip)
 
 ### Consolidated CSV and Excel file representations of profiles 
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -80,11 +80,11 @@ parameters:  # see https://confluence.hl7.org/display/FHIR/Implementation+Guide+
   apply-jurisdiction: true
   apply-publisher: true
   apply-version: true
-  show-inherited-invariants: true
+  show-inherited-invariants: false
   usage-stats-opt-out: true
-  excludexml: true
-  excludejson: true
-  excludettl: true
+  excludexml: false
+  excludejson: false
+  excludettl: false
   excludemap: true
   shownav: false
   # generate: #what does this do - todo: remove and see4


### PR DESCRIPTION
Changes included: 
- Enable XML, JSON, TTL tables in profile pages
- Remove Search Parameters and Operations menu item
- Update Downloads page to include full content