### PR TITLE
ServiceRequest wave2 and FMM level changes & IG standard status and cannonical URL changes

### DIFF
--- a/ig.ini
+++ b/ig.ini
@@ -1,4 +1,4 @@
 [IG]
-ig = fsh-generated/resources/ImplementationGuide-hl7.fhir.au.erequesting.json
+ig = fsh-generated/resources/ImplementationGuide-hl7.fhir.au.ereq.json
 template = hl7.au.sparked.template#current
 

--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -3,5 +3,4 @@ Alias: $loinc = http://loinc.org
 
 // AU Core profiles
 Alias: $AUCorePatient = http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient
-Alias: $AUCorePractitionerRole = http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitionerrole
 Alias: $AULocalOrderIdentifier = http://hl7.org.au/fhir/StructureDefinition/au-localorderidentifier

--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -1,2 +1,7 @@
 Alias: $sct = http://snomed.info/sct
 Alias: $loinc = http://loinc.org
+
+// AU Core profiles
+Alias: $AUCorePatient = http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient
+Alias: $AUCorePractitionerRole = http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitionerrole
+Alias: $AULocalOrderIdentifier = http://hl7.org.au/fhir/StructureDefinition/au-localorderidentifier

--- a/input/fsh/au-erequesting-servicerequest.fsh
+++ b/input/fsh/au-erequesting-servicerequest.fsh
@@ -6,10 +6,7 @@ Description: "This profile defines a service request structure to represent a re
 
 * ^status = #draft
 
-* ^extension.url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm"
-* ^extension.valueInteger = 0
-* ^extension.url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status"
-* ^extension.valueCode = #draft
+* ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 0
 
 * . ^short = "A diagnostic service request"
 
@@ -18,27 +15,25 @@ Description: "This profile defines a service request structure to represent a re
 
 * status MS
 
-* intent 1..1
-* intent MS
+* intent 1..1 MS
+* intent = #order
 
-* code 1..1
-* code MS
+* code 1..1 MS
 
 * subject MS
-* subject MS
+* subject only Reference(AUCorePatient)
 
-* authoredOn 1..1
-* authoredOn MS 
+
+* authoredOn 1..1 MS
 * authoredOn obeys au-ereq-srr-00
 
-* requester 1..1
-* requester MS
+* requester 1..1 MS
+* requester only Reference(AUCorePractitionerRole)
 
-* requisition 1..1
-* requisition MS 
+* requisition 1..1 MS
+* requisition ^type.profile = "http://hl7.org.au/fhir/StructureDefinition/au-localorderidentifier"
 
-* category 1..*
-* category MS
+* category 1..* MS
 * category obeys au-ereq-srr-01
 
 * note MS

--- a/input/fsh/au-erequesting-servicerequest.fsh
+++ b/input/fsh/au-erequesting-servicerequest.fsh
@@ -28,7 +28,7 @@ Description: "This profile defines a service request structure to represent a re
 * authoredOn obeys au-ereq-srr-00
 
 * requester 1..1 MS
-* requester only Reference(AUCorePractitionerRole)
+* requester only Reference(PractitionerRole)
 
 * requisition 1..1 MS
 * requisition ^type.profile = "http://hl7.org.au/fhir/StructureDefinition/au-localorderidentifier"

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -9,6 +9,13 @@ name: AUeRequesting
 title: AU eRequesting
 description: This implementation guide is provided to support the use of FHIR®© for clinical requesting and ordering in an Australian context. , and defines the minimum set of constraints on the FHIR resources to create the AU eRequesting profiles.
 status: draft # draft | active | retired | unknown
+extension:
+  - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-wg  #<<< must include a http://hl7.org/fhir/StructureDefinition/structuredefinition-wg extension that identifies the workgroup responsible for the IG. This is the authoritative element.
+    valueCode: HAFWG  
+  - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+    valueCode: draft
+  - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm  #<<<<< the default FMM level for the artifacts in this IG
+    valueInteger: 0
 version: 0.1.0-ci-build
 fhirVersion: 4.0.1
 copyright: Used by permission of HL7 International, all rights reserved Creative Commons License. HL7 Australia© 2024+; Licensed Under Creative Commons No Rights Reserved.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -3,8 +3,8 @@
 # │  used properties are included. For a list of all supported properties and their functions,     │
 # │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
-id: hl7.fhir.au.erequesting
-canonical: http://hl7.org.au/fhir/erequesting
+id: hl7.fhir.au.ereq
+canonical: http://hl7.org.au/fhir/ereq
 name: AUeRequesting
 title: AU eRequesting
 description: This implementation guide is provided to support the use of FHIR®© for clinical requesting and ordering in an Australian context. , and defines the minimum set of constraints on the FHIR resources to create the AU eRequesting profiles.


### PR DESCRIPTION
Changes included: 

- ServiceRequest Wave 2 agreements https://confluence.hl7.org/pages/viewpage.action?pageId=254640390: 
  -  Service.Request.subject reference to AU Core Patient
  - ServiceRequest.requester reference to Practitioner Role
  - ServiceRequest.intent has fixed value=order
  -  ServiceRequest.requisition typed to AU Local Order Identifier (Noting that the change to enforce identifier.type to PGN is not included in this PR)
- Fixed ServiceRequest FMM level - it now gets rendered in the output
- Added Implementation Guide Standard Status and FMM level - it now gets rendered in the output
- Changed the canonical and package id to use 'ereq' instead of 'erequesting'