### PR TITLE
Updated 1.4 How to read this guide

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -29,7 +29,9 @@ This guide is divided into several pages which are listed at the top of each pag
   - [AU Variance Statement](variance.html): This page documents variance from AU Base and AU Core.
   - [Future of AU eRequesting](erequesting-future.html): This is a placeholder for when content becomes available.
 - [Use Cases](use-cases.html): This page describes the use cases in scope of eRequesting R1. 
-- [FHIR Artefacts](artifacts.html): This is a placeholder for when content becomes available.
+- [FHIR Artefacts](artifacts.html): These pages provide detailed descriptions and formal definitions for all the FHIR artefacts defined in this guide.
+  - [Profiles and Extensions](profiles-and-extensions.html): This set of pages describes the profiles and extensions that are defined in this guide to exchange quality data. Each profile page includes a narrative description and guidance, formal definition and a "Quick Start" guide which summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
+  - [Terminology](terminology.html): This set of pages lists the value sets and code systems defined in this guide.
 - [Examples](examples.html): This is a placeholder for when content becomes available.
 - [Downloads](downloads.html): This is a placeholder for when content becomes available.
 


### PR DESCRIPTION
Added description for FHIR artefact, and subheadings and descriptions for Profiles and Extensions and Terminology (noting terminology page is still 'TBD').