### PR TITLE
AU eRequesting ServiceRequest :: Wave 2 changes

### DIFF
--- a/fsh-generated/fsh-index.json
+++ b/fsh-generated/fsh-index.json
@@ -1,10 +1,10 @@
 [
   {
-    "outputFile": "StructureDefinition-fish-patient.json",
-    "fshName": "FishPatient",
+    "outputFile": "StructureDefinition-au-erequesting-servicerequest.json",
+    "fshName": "AUeRequestingServiceRequest",
     "fshType": "Profile",
-    "fshFile": "FishPatient.fsh",
+    "fshFile": "au-erequesting-servicerequest.fsh",
     "startLine": 1,
-    "endLine": 6
+    "endLine": 53
   }
 ]

--- a/fsh-generated/fsh-index.json
+++ b/fsh-generated/fsh-index.json
@@ -5,6 +5,6 @@
     "fshType": "Profile",
     "fshFile": "au-erequesting-servicerequest.fsh",
     "startLine": 1,
-    "endLine": 53
+    "endLine": 54
   }
 ]

--- a/fsh-generated/fsh-index.txt
+++ b/fsh-generated/fsh-index.txt
@@ -1,2 +1,2 @@
-Output File                            Name         Type     FSH File         Lines
-StructureDefinition-fish-patient.json  FishPatient  Profile  FishPatient.fsh  1 - 6
+Output File                                             Name                         Type     FSH File                           Lines
+StructureDefinition-au-erequesting-servicerequest.json  AUeRequestingServiceRequest  Profile  au-erequesting-servicerequest.fsh  1 - 53

--- a/fsh-generated/fsh-index.txt
+++ b/fsh-generated/fsh-index.txt
@@ -1,2 +1,2 @@
 Output File                                             Name                         Type     FSH File                           Lines
-StructureDefinition-au-erequesting-servicerequest.json  AUeRequestingServiceRequest  Profile  au-erequesting-servicerequest.fsh  1 - 53
+StructureDefinition-au-erequesting-servicerequest.json  AUeRequestingServiceRequest  Profile  au-erequesting-servicerequest.fsh  1 - 54

--- a/fsh-generated/includes/fsh-link-references.md
+++ b/fsh-generated/includes/fsh-link-references.md
@@ -1,1 +1,1 @@
-[ERequestingServiceRequest]: StructureDefinition-au-erequesting-servicerequest.html
+[AUeRequestingServiceRequest]: StructureDefinition-au-erequesting-servicerequest.html

--- a/fsh-generated/resources/ImplementationGuide-hl7.fhir.au.ereq.json
+++ b/fsh-generated/resources/ImplementationGuide-hl7.fhir.au.ereq.json
@@ -1,10 +1,20 @@
 {
   "resourceType": "ImplementationGuide",
-  "id": "hl7.fhir.au.erequesting",
-  "url": "http://hl7.org.au/fhir/erequesting/ImplementationGuide/hl7.fhir.au.erequesting",
+  "id": "hl7.fhir.au.ereq",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+      "valueCode": "draft"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
+      "valueInteger": 0
+    }
+  ],
+  "url": "http://hl7.org.au/fhir/ereq/ImplementationGuide/hl7.fhir.au.ereq",
   "version": "0.1.0-ci-build",
-  "name": "AUeRequesting",
-  "title": "AU eRequesting",
+  "name": "AUeRequestingImplementationGuide",
+  "title": "AU eRequesting Implementation Guide",
   "status": "draft",
   "publisher": "HL7 Australia",
   "contact": [
@@ -40,7 +50,7 @@
     }
   ],
   "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License. HL7 Australia© 2024+; Licensed Under Creative Commons No Rights Reserved.",
-  "packageId": "hl7.fhir.au.erequesting",
+  "packageId": "hl7.fhir.au.ereq",
   "license": "CC0-1.0",
   "fhirVersion": [
     "4.0.1"
@@ -65,7 +75,7 @@
         "reference": {
           "reference": "StructureDefinition/au-erequesting-servicerequest"
         },
-        "name": "eRequesting ServiceRequest",
+        "name": "AU eRequesting ServiceRequest",
         "description": "This profile defines a service request structure to represent a request for a diagnostic investigation. It is based on the [AU Base Diagnostic Request](http://hl7.org.au/fhir/StructureDefinition/au-diagnosticrequest).",
         "exampleBoolean": false
       }
@@ -91,13 +101,18 @@
           "generation": "markdown",
           "page": [
             {
-              "nameUrl": "erequesting-future.html",
+              "nameUrl": "future.html",
               "title": "Future of AU eRequesting",
               "generation": "markdown"
             },
             {
               "nameUrl": "relationship.html",
               "title": "Relationship with other HL7 AU FHIR IGs",
+              "generation": "markdown"
+            },
+            {
+              "nameUrl": "variance.html",
+              "title": "AU Variance Statement",
               "generation": "markdown"
             },
             {
@@ -142,6 +157,11 @@
         {
           "nameUrl": "downloads.html",
           "title": "Downloads",
+          "generation": "markdown"
+        },
+        {
+          "nameUrl": "license.html",
+          "title": "License",
           "generation": "markdown"
         }
       ]
@@ -193,7 +213,7 @@
       },
       {
         "code": "show-inherited-invariants",
-        "value": "true"
+        "value": "false"
       },
       {
         "code": "usage-stats-opt-out",
@@ -201,15 +221,15 @@
       },
       {
         "code": "excludexml",
-        "value": "true"
+        "value": "false"
       },
       {
         "code": "excludejson",
-        "value": "true"
+        "value": "false"
       },
       {
         "code": "excludettl",
-        "value": "true"
+        "value": "false"
       },
       {
         "code": "excludemap",

--- a/fsh-generated/resources/StructureDefinition-au-erequesting-servicerequest.json
+++ b/fsh-generated/resources/StructureDefinition-au-erequesting-servicerequest.json
@@ -93,6 +93,11 @@
         "mustSupport": true
       },
       {
+        "id": "ServiceRequest.code.text",
+        "path": "ServiceRequest.code.text",
+        "min": 1
+      },
+      {
         "id": "ServiceRequest.subject",
         "path": "ServiceRequest.subject",
         "type": [

--- a/fsh-generated/resources/StructureDefinition-au-erequesting-servicerequest.json
+++ b/fsh-generated/resources/StructureDefinition-au-erequesting-servicerequest.json
@@ -3,14 +3,13 @@
   "id": "au-erequesting-servicerequest",
   "extension": [
     {
-      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-      "valueInteger": 0,
-      "valueCode": "draft"
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
+      "valueInteger": 0
     }
   ],
-  "url": "http://hl7.org.au/fhir/erequesting/StructureDefinition/au-erequesting-servicerequest",
-  "name": "ERequestingServiceRequest",
-  "title": "eRequesting ServiceRequest",
+  "url": "http://hl7.org.au/fhir/ereq/StructureDefinition/au-erequesting-servicerequest",
+  "name": "AUeRequestingServiceRequest",
+  "title": "AU eRequesting ServiceRequest",
   "status": "draft",
   "description": "This profile defines a service request structure to represent a request for a diagnostic investigation. It is based on the [AU Base Diagnostic Request](http://hl7.org.au/fhir/StructureDefinition/au-diagnosticrequest).",
   "fhirVersion": "4.0.1",
@@ -24,7 +23,16 @@
       {
         "id": "ServiceRequest",
         "path": "ServiceRequest",
-        "short": "A diagnostic service request"
+        "short": "A diagnostic service request",
+        "constraint": [
+          {
+            "key": "au-ereq-srr-02",
+            "severity": "error",
+            "human": "Category SHALL either be SNOMED CT 108252007 |Laboratory procedure or SNOMED CT 363679005 |Imaging",
+            "expression": "category.coding.where(system='http://snomed.info/sct' and code='108252007').exists() or category.coding.where(system='http://snomed.info/sct' and code='363679005').exists()",
+            "source": "http://hl7.org.au/fhir/ereq/StructureDefinition/au-erequesting-servicerequest"
+          }
+        ]
       },
       {
         "id": "ServiceRequest.identifier",
@@ -35,17 +43,41 @@
         "id": "ServiceRequest.requisition",
         "path": "ServiceRequest.requisition",
         "min": 1,
+        "type": [
+          {
+            "code": "Identifier",
+            "profile": [
+              "http://hl7.org.au/fhir/StructureDefinition/au-localorderidentifier"
+            ]
+          }
+        ],
         "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.requisition.type.coding",
+        "path": "ServiceRequest.requisition.type.coding",
+        "min": 1,
+        "max": "1"
+      },
+      {
+        "id": "ServiceRequest.requisition.type.coding.system",
+        "path": "ServiceRequest.requisition.type.coding.system",
+        "patternUri": "http://terminology.hl7.org/CodeSystem/v2-0203"
+      },
+      {
+        "id": "ServiceRequest.requisition.type.coding.code",
+        "path": "ServiceRequest.requisition.type.coding.code",
+        "patternCode": "PGN"
       },
       {
         "id": "ServiceRequest.status",
         "path": "ServiceRequest.status",
-        "patternCode": "draft",
         "mustSupport": true
       },
       {
         "id": "ServiceRequest.intent",
         "path": "ServiceRequest.intent",
+        "patternCode": "order",
         "mustSupport": true
       },
       {
@@ -63,18 +95,89 @@
       {
         "id": "ServiceRequest.subject",
         "path": "ServiceRequest.subject",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient"
+            ]
+          }
+        ],
         "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.encounter",
+        "path": "ServiceRequest.encounter",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org.au/fhir/core/StructureDefinition/au-core-encounter"
+            ]
+          }
+        ],
+        "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.encounter.reference",
+        "path": "ServiceRequest.encounter.reference",
+        "min": 1
       },
       {
         "id": "ServiceRequest.authoredOn",
         "path": "ServiceRequest.authoredOn",
         "min": 1,
+        "constraint": [
+          {
+            "key": "au-ereq-srr-01",
+            "severity": "error",
+            "human": "Date must include at least year, month, and day",
+            "expression": "$this.toString().matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}$')",
+            "source": "http://hl7.org.au/fhir/ereq/StructureDefinition/au-erequesting-servicerequest"
+          }
+        ],
         "mustSupport": true
       },
       {
         "id": "ServiceRequest.requester",
         "path": "ServiceRequest.requester",
         "min": 1,
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+            ]
+          }
+        ],
+        "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.reasonCode",
+        "path": "ServiceRequest.reasonCode",
+        "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.insurance",
+        "path": "ServiceRequest.insurance",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org.au/fhir/StructureDefinition/au-coverage"
+            ]
+          }
+        ],
+        "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.bodySite",
+        "path": "ServiceRequest.bodySite",
+        "mustSupport": true
+      },
+      {
+        "id": "ServiceRequest.note",
+        "path": "ServiceRequest.note",
         "mustSupport": true
       }
     ]

--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -3,4 +3,8 @@ Alias: $loinc = http://loinc.org
 
 // AU Core profiles
 Alias: $AUCorePatient = http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient
+Alias: $AUCoreEncounter = http://hl7.org.au/fhir/core/StructureDefinition/au-core-encounter
+
+// AU Base profiles
 Alias: $AULocalOrderIdentifier = http://hl7.org.au/fhir/StructureDefinition/au-localorderidentifier
+Alias: $AUBaseCoverage = http://hl7.org.au/fhir/StructureDefinition/au-coverage

--- a/input/fsh/au-erequesting-servicerequest.fsh
+++ b/input/fsh/au-erequesting-servicerequest.fsh
@@ -40,10 +40,15 @@ Description: "This profile defines a service request structure to represent a re
 * note MS
 
 * insurance MS
+* insurance only Reference(AUBaseCoverage)
 
 * encounter MS
+* encounter only Reference(AUCoreEncounter)
+* encounter.reference 1..1
 
 * reasonCode MS
+
+* bodySite MS
 
 * obeys au-ereq-srr-02
 

--- a/input/fsh/au-erequesting-servicerequest.fsh
+++ b/input/fsh/au-erequesting-servicerequest.fsh
@@ -19,6 +19,7 @@ Description: "This profile defines a service request structure to represent a re
 * intent = #order
 
 * code 1..1 MS
+* code.text 1..1
 
 * subject MS
 * subject only Reference(AUCorePatient)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -10,8 +10,6 @@ title: AU eRequesting Implementation Guide
 description: This implementation guide is provided to support the use of FHIR®© for clinical requesting and ordering in an Australian context. , and defines the minimum set of constraints on the FHIR resources to create the AU eRequesting profiles.
 status: draft # draft | active | retired | unknown
 extension:
-  - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-wg  #<<< must include a http://hl7.org/fhir/StructureDefinition/structuredefinition-wg extension that identifies the workgroup responsible for the IG. This is the authoritative element.
-    valueCode: HAFWG  
   - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
     valueCode: draft
   - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm  #<<<<< the default FMM level for the artifacts in this IG


### PR DESCRIPTION
This PR addresses some of the voted in [2024-07-04 AU eRequesting TDG Agenda/Minutes](https://confluence.hl7.org/pages/viewpage.action?pageId=256181856) and [2024-07-09 AU eRequesting TDG Agenda/Minutes](https://confluence.hl7.org/pages/viewpage.action?pageId=256181864): 

Changes included:
- ServiceRequest.encounter
  - add MS
  - type to AU Core Encounter 
  - make ServiceRequest.encounter.reference 1..1
- ServiceRequest.bodySite
  - add MS
  - noting that the binding to NCTS Body Site (preferred) is inherited from AU Base - no change required in the profile
- ServiceRequest.insurance
  -  type to AU Base Coverage
- ServiceRequest.code
  - make ServiceRequest.code.text 1..1 
- and an additional change to remove QA Report error related to 'HAFWG' value
 

Noting that there are no changes related to the following motions as already satisfied by the profile: 
- ServiceRequest.identifier is Must Support with cardinality 0..* and any identifier is allowed
- to not further constrain ServiceRequest.note
- that ServiceRequest.reasonCode uses ValueSet NCTS Reason for Request and binding strength is preferred

Changes related to ServiceRequest.code terminology will be addressed in another PR. 

