### PR TITLE
Add AU eRequesting Placer, AU eRequesting Filler and AU eRequesting Patient Access actors

### DIFF
--- a/fsh-generated/fsh-index.json
+++ b/fsh-generated/fsh-index.json
@@ -1,5 +1,29 @@
 [
   {
+    "outputFile": "ActorDefinition-au-erequesting-actor-filler.json",
+    "fshName": "au-erequesting-actor-filler",
+    "fshType": "Instance",
+    "fshFile": "actors.fsh",
+    "startLine": 12,
+    "endLine": 21
+  },
+  {
+    "outputFile": "ActorDefinition-au-erequesting-actor-patientaccess.json",
+    "fshName": "au-erequesting-actor-patientaccess",
+    "fshType": "Instance",
+    "fshFile": "actors.fsh",
+    "startLine": 24,
+    "endLine": 33
+  },
+  {
+    "outputFile": "ActorDefinition-au-erequesting-actor-placer.json",
+    "fshName": "au-erequesting-actor-placer",
+    "fshType": "Instance",
+    "fshFile": "actors.fsh",
+    "startLine": 1,
+    "endLine": 10
+  },
+  {
     "outputFile": "StructureDefinition-au-erequesting-servicerequest.json",
     "fshName": "AUeRequestingServiceRequest",
     "fshType": "Profile",

--- a/fsh-generated/fsh-index.txt
+++ b/fsh-generated/fsh-index.txt
@@ -1,2 +1,5 @@
-Output File                                             Name                         Type     FSH File                           Lines
-StructureDefinition-au-erequesting-servicerequest.json  AUeRequestingServiceRequest  Profile  au-erequesting-servicerequest.fsh  1 - 54
+Output File                                              Name                                Type      FSH File                           Lines
+ActorDefinition-au-erequesting-actor-filler.json         au-erequesting-actor-filler         Instance  actors.fsh                         12 - 21
+ActorDefinition-au-erequesting-actor-patientaccess.json  au-erequesting-actor-patientaccess  Instance  actors.fsh                         24 - 33
+ActorDefinition-au-erequesting-actor-placer.json         au-erequesting-actor-placer         Instance  actors.fsh                         1 - 10
+StructureDefinition-au-erequesting-servicerequest.json   AUeRequestingServiceRequest         Profile   au-erequesting-servicerequest.fsh  1 - 54

--- a/fsh-generated/includes/fsh-link-references.md
+++ b/fsh-generated/includes/fsh-link-references.md
@@ -1,1 +1,4 @@
+[au-erequesting-actor-filler]: ActorDefinition-au-erequesting-actor-filler.html
+[au-erequesting-actor-patientaccess]: ActorDefinition-au-erequesting-actor-patientaccess.html
+[au-erequesting-actor-placer]: ActorDefinition-au-erequesting-actor-placer.html
 [AUeRequestingServiceRequest]: StructureDefinition-au-erequesting-servicerequest.html

--- a/fsh-generated/resources/ActorDefinition-au-erequesting-actor-filler.json
+++ b/fsh-generated/resources/ActorDefinition-au-erequesting-actor-filler.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "ActorDefinition",
+  "id": "au-erequesting-actor-filler",
+  "url": "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-filler",
+  "name": "AUeRequestingFiller",
+  "title": "AU eRequesting Filler",
+  "status": "draft",
+  "description": "The AU eRequesting Filler is a system responsible for finding and retrieving diagnostic service requests so that service providers can fulfil them It ensures that service providers have the necessary details to fulfil the requests and manages the requests through the fulfilment process.",
+  "type": "system",
+  "documentation": "An AU eRequesting Filler (client): TBD"
+}

--- a/fsh-generated/resources/ActorDefinition-au-erequesting-actor-patientaccess.json
+++ b/fsh-generated/resources/ActorDefinition-au-erequesting-actor-patientaccess.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "ActorDefinition",
+  "id": "au-erequesting-actor-patientaccess",
+  "url": "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-patientaccess",
+  "name": "AUeRequestingPatientAccess",
+  "title": "AU eRequesting Patient Access",
+  "status": "draft",
+  "description": "The AU eRequesting Patient Access system is the digital interface that allows patients or their representatives to view and manage their requests for diagnostic services. It provides access to request details, enabling patients to choose service providers and track the status of their requests.",
+  "type": "system",
+  "documentation": "An AU eRequesting Patient Access (client): TBD"
+}

--- a/fsh-generated/resources/ActorDefinition-au-erequesting-actor-placer.json
+++ b/fsh-generated/resources/ActorDefinition-au-erequesting-actor-placer.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "ActorDefinition",
+  "id": "au-erequesting-actor-placer",
+  "url": "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-placer",
+  "name": "AUeRequestingPlacer",
+  "title": "AU eRequesting Placer",
+  "status": "draft",
+  "description": "The AU eRequesting Placer system is responsible for initiating and creating patient diagnostic service requests. This system connects to enable requesters to provide the necessary information to create a request, ensuring that all required data is accurately collected and provided to service providers with sufficient information for them to fulfil the request.",
+  "type": "system",
+  "documentation": "AU eRequesting Placer (client): TBD"
+}

--- a/fsh-generated/resources/ImplementationGuide-hl7.fhir.au.ereq.json
+++ b/fsh-generated/resources/ImplementationGuide-hl7.fhir.au.ereq.json
@@ -73,6 +73,30 @@
     "resource": [
       {
         "reference": {
+          "reference": "ActorDefinition/au-erequesting-actor-filler"
+        },
+        "name": "AU eRequesting Filler",
+        "description": "The AU eRequesting Filler is a system responsible for finding and retrieving diagnostic service requests so that service providers can fulfil them It ensures that service providers have the necessary details to fulfil the requests and manages the requests through the fulfilment process.",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
+          "reference": "ActorDefinition/au-erequesting-actor-patientaccess"
+        },
+        "name": "AU eRequesting Patient Access",
+        "description": "The AU eRequesting Patient Access system is the digital interface that allows patients or their representatives to view and manage their requests for diagnostic services. It provides access to request details, enabling patients to choose service providers and track the status of their requests.",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
+          "reference": "ActorDefinition/au-erequesting-actor-placer"
+        },
+        "name": "AU eRequesting Placer",
+        "description": "The AU eRequesting Placer system is responsible for initiating and creating patient diagnostic service requests. This system connects to enable requesters to provide the necessary information to create a request, ensuring that all required data is accurately collected and provided to service providers with sufficient information for them to fulfil the request.",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
           "reference": "StructureDefinition/au-erequesting-servicerequest"
         },
         "name": "AU eRequesting ServiceRequest",
@@ -147,6 +171,11 @@
         {
           "nameUrl": "terminology.html",
           "title": "Terminology",
+          "generation": "markdown"
+        },
+        {
+          "nameUrl": "actors.html",
+          "title": "Actor Definitions",
           "generation": "markdown"
         },
         {

--- a/input/fsh/actors.fsh
+++ b/input/fsh/actors.fsh
@@ -1,0 +1,33 @@
+Instance: au-erequesting-actor-placer
+InstanceOf: ActorDefinition
+Usage: #definition
+* url = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-placer"
+* name = "AUeRequestingPlacer"
+* title = "AU eRequesting Placer"
+* status = #draft
+* description = "The AU eRequesting Placer system is responsible for initiating and creating patient diagnostic service requests. This system connects to enable requesters to provide the necessary information to create a request, ensuring that all required data is accurately collected and provided to service providers with sufficient information for them to fulfil the request."
+* type = #system
+* documentation = "AU eRequesting Placer (client): TBD"
+
+Instance: au-erequesting-actor-filler
+InstanceOf: ActorDefinition
+Usage: #definition
+* url = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-filler"
+* name = "AUeRequestingFiller"
+* title = "AU eRequesting Filler"
+* status = #draft
+* description = "The AU eRequesting Filler is a system responsible for finding and retrieving diagnostic service requests so that service providers can fulfil them It ensures that service providers have the necessary details to fulfil the requests and manages the requests through the fulfilment process."
+* type = #system
+* documentation = "An AU eRequesting Filler (client): TBD"
+
+
+Instance: au-erequesting-actor-patientaccess
+InstanceOf: ActorDefinition
+Usage: #definition
+* url = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-patientaccess"
+* name = "AUeRequestingPatientAccess"
+* title = "AU eRequesting Patient Access"
+* status = #draft
+* description = "The AU eRequesting Patient Access system is the digital interface that allows patients or their representatives to view and manage their requests for diagnostic services. It provides access to request details, enabling patients to choose service providers and track the status of their requests."
+* type = #system
+* documentation = "An AU eRequesting Patient Access (client): TBD"

--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -8,3 +8,8 @@ Alias: $AUCoreEncounter = http://hl7.org.au/fhir/core/StructureDefinition/au-cor
 // AU Base profiles
 Alias: $AULocalOrderIdentifier = http://hl7.org.au/fhir/StructureDefinition/au-localorderidentifier
 Alias: $AUBaseCoverage = http://hl7.org.au/fhir/StructureDefinition/au-coverage
+
+//  Actors
+Alias: $placer = http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-placer
+Alias: $filler = http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-filler
+Alias: $patientaccess = http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-patientaccess

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -1,5 +1,11 @@
 == Suppressed Messages ==
 
-# Add warning and/or information messages here after you've confirmed that they aren't really a problem
-# (And include comments like this justifying why)
-# See https://github.com/FHIR/sample-ig/blob/master/input/ignoreWarnings.txt for examples
+
+
+# ================================================================================
+# ===  ERRORS ===
+# ===========================================================-=====================
+# ===  These errors are pending an update to the IG publisher for resolution; currently, there is no timeline for their correction. They are related by R4 and R5 value sets having different values, but using an R4 values returns the same error. See https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/QA.20error.20with.20ActorDefinition.20in.20R4.20IG ====
+ERROR: ActorDefinition/au-erequesting-actor-filler: ActorDefinition.type: The value provided ('system') was not found in the value set 'Example Scenario Actor Type' (http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0), and a code is required from this value set  (error message = The System URI could not be determined for the code 'system' in the ValueSet 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0'; The provided code '#system' was not found in the value set 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0')
+ERROR: ActorDefinition/au-erequesting-actor-patientaccess: ActorDefinition.type: The value provided ('system') was not found in the value set 'Example Scenario Actor Type' (http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0), and a code is required from this value set  (error message = The System URI could not be determined for the code 'system' in the ValueSet 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0'; The provided code '#system' was not found in the value set 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0')
+ERROR: ActorDefinition/au-erequesting-actor-placer: ActorDefinition.type: The value provided ('system') was not found in the value set 'Example Scenario Actor Type' (http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0), and a code is required from this value set  (error message = The System URI could not be determined for the code 'system' in the ValueSet 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0'; The provided code '#system' was not found in the value set 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0')

--- a/input/includes/menu.xml
+++ b/input/includes/menu.xml
@@ -54,6 +54,9 @@
         <!-- <li>
         <a href="capability-statements.html">Capability Statements</a>
       </li> -->
+      <li>
+        <a href="actors.html">Actor Definitions</a>
+      </li>
     </ul>
   </li>
   <li>

--- a/input/pagecontent/actors.md
+++ b/input/pagecontent/actors.md
@@ -1,0 +1,13 @@
+The following ActorDefinitions define the systems that plays a role in data exchange, and that have obligations associated with the role the actor plays, in AU eRequesting.
+
+- [AU eRequesting Placer actor](ActorDefinition-au-erequesting-actor-placer.html)
+
+The AU eRequesting Placer system is responsible for initiating and creating patient diagnostic service requests. This system connects to enable requesters to provide the necessary information to create a request, ensuring that all required data is accurately collected and provided to service providers with sufficient information for them to fulfil the request.
+
+- [AU eRequesting Filler actor](ActorDefinition-au-erequesting-actor-filler.html)
+
+The AU eRequesting Filler is a system responsible for finding and retrieving diagnostic service requests so that service providers can fulfil them It ensures that service providers have the necessary details to fulfil the requests and manages the requests through the fulfilment process.
+
+- [AU eRequesting Patient Access actor](ActorDefinition-au-erequesting-actor-patientaccess.html)
+
+The AU eRequesting Patient Access system is the digital interface that allows patients or their representatives to view and manage their requests for diagnostic services. It provides access to request details, enabling patients to choose service providers and track the status of their requests.

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -32,6 +32,7 @@ This guide is divided into several pages which are listed at the top of each pag
 - [FHIR Artefacts](artifacts.html): These pages provide detailed descriptions and formal definitions for all the FHIR artefacts defined in this guide.
   - [Profiles and Extensions](profiles-and-extensions.html): This set of pages describes the profiles and extensions that are defined in this guide to exchange quality data. Each profile page includes a narrative description and guidance, formal definition and a "Quick Start" guide which summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
   - [Terminology](terminology.html): This set of pages lists the value sets and code systems defined in this guide.
+  - [Actor Definitions](actors.html): This set of pages define the AU aRequesting actors, AU eRequesting Placer, AU eRequesting Filler and AU eRequesting Patient Access.
 - [Examples](examples.html): This is a placeholder for when content becomes available.
 - [Downloads](downloads.html): This is a placeholder for when content becomes available.
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -64,6 +64,8 @@ pages:
     # capability-statements.md:
     search-parameters-and-operations.md:
   terminology.md:
+  actors.md:
+    title: Actor Definitions
   examples.md:
   downloads.md:
   license.md:


### PR DESCRIPTION
As agreed in [AU eRequesting Patient Access](https://confluence.hl7.org/pages/viewpage.action?pageId=256181864), 
add actors: AU eRequesting Placer, AU eRequesting Filler and AU eRequesting Patient Access. 

Changes:
- add ActorDefinitions: AU eRequesting Placer, AU eRequesting Filler and AU eRequesting Patient Access
- include new menu item FHIR Artefacts > Actor Defintions
- update How to read this guide to include ActorDefinitions page
- annotate the QA Report errors related ActorDefinition.type tooling issues 