### PR TITLE
Update how to read section in line with other IGs.

### DIFF
--- a/fsh-generated/resources/ImplementationGuide-hl7.fhir.au.ereq.json
+++ b/fsh-generated/resources/ImplementationGuide-hl7.fhir.au.ereq.json
@@ -131,7 +131,7 @@
             },
             {
               "nameUrl": "relationship.html",
-              "title": "Relationship with other HL7 AU FHIR IGs",
+              "title": "Relationship with other IGs",
               "generation": "markdown"
             },
             {

--- a/fsh-generated/resources/ImplementationGuide-hl7.fhir.au.ereq.json
+++ b/fsh-generated/resources/ImplementationGuide-hl7.fhir.au.ereq.json
@@ -184,14 +184,21 @@
           "generation": "markdown"
         },
         {
-          "nameUrl": "downloads.html",
-          "title": "Downloads",
-          "generation": "markdown"
-        },
-        {
-          "nameUrl": "license.html",
-          "title": "License",
-          "generation": "markdown"
+          "nameUrl": "support.html",
+          "title": "Support",
+          "generation": "markdown",
+          "page": [
+            {
+              "nameUrl": "downloads.html",
+              "title": "Downloads",
+              "generation": "markdown"
+            },
+            {
+              "nameUrl": "license.html",
+              "title": "License",
+              "generation": "markdown"
+            }
+          ]
         }
       ]
     },

--- a/input/includes/menu.xml
+++ b/input/includes/menu.xml
@@ -27,7 +27,7 @@
         <a href="auereqdi.html">AU eRequesting Data for Interoperability</a>
       </li>
       <li>
-        <a href="relationship.html">Relationship with other HL7 AU FHIR IGs</a>
+        <a href="relationship.html">Relationship with other IGs</a>
       </li>
       <li>
         <a href="variance.html">AU Variance Statement</a>

--- a/input/pagecontent/guidance.md
+++ b/input/pagecontent/guidance.md
@@ -1,4 +1,5 @@
 - [eRequesting Data for Interoperability](auereqdi.html)
 - [Relationship with other HL7 AU FHIR IGs](relationship.html)
+- [AU Variance Statement](variance.html)
 - [Future of AU eRequesting](future.html)
 

--- a/input/pagecontent/guidance.md
+++ b/input/pagecontent/guidance.md
@@ -1,5 +1,5 @@
 - [eRequesting Data for Interoperability](auereqdi.html)
-- [Relationship with other HL7 AU FHIR IGs](relationship.html)
+- [Relationship with other IGs](relationship.html)
 - [AU Variance Statement](variance.html)
 - [Future of AU eRequesting](future.html)
 

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -41,19 +41,21 @@ A system that is the digital interface that allows patients or their representat
 This guide is divided into several pages which are listed at the top of each page in the menu bar.
 
 - [Home](index.html): This page provides the introduction and scope for this guide.
-- [Conformance](conformance.html): This is a placeholder for when content becomes available.
-- [Guidance](guidance.html): This is a placeholder for when content becomes available.
-  - [AU eRequesting data for interoperability](auereqdi.html): This is a placeholder for when content becomes available.
-  - [Relationship with other HL7 AU FHIR IGs](relationship.html): This is a placeholder for when content becomes available.
+- [Conformance](conformance.html): This page describes the set of rules to claim conformance to this guide
+- [Guidance](guidance.html): These pages list the guidance for this guide. 
+  - [AU eRequesting Data for Interoperability](auereqdi.html): This page maps the AU eRequesting resources and elements to AUeReqDI data classes and data elements.
+  - [Relationship with other HL7 AU FHIR IGs](relationship.html): This page provides guidance on the relationship between AU eRequesting and other implementation guides.
   - [AU Variance Statement](variance.html): This page documents variance from AU Base and AU Core.
   - [Future of AU eRequesting](future.html): This page outlines the approach to developing AU eRequesting and yearly update cycle.
 - [Use Cases](use-cases.html): This page describes the use cases in scope of eRequesting R1. 
 - [FHIR Artefacts](artifacts.html): These pages provide detailed descriptions and formal definitions for all the FHIR artefacts defined in this guide.
-  - [Profiles and Extensions](profiles-and-extensions.html): This set of pages describes the profiles and extensions that are defined in this guide to exchange quality data. Each profile page includes a narrative description and guidance, formal definition and a "Quick Start" guide which summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
-  - [Terminology](terminology.html): This set of pages lists the value sets and code systems defined in this guide.
-  - [Actor Definitions](actors.html): This set of pages define the AU aRequesting actors, AU eRequesting Placer, AU eRequesting Filler and AU eRequesting Patient Access.
-- [Examples](examples.html): This is a placeholder for when content becomes available.
-- [Downloads](downloads.html): This is a placeholder for when content becomes available.
+  - [Profiles and Extensions](profiles-and-extensions.html): This page describes the profiles and extensions that are defined in this guide to exchange quality data. Each profile page includes a narrative description and guidance, formal definition and a "Quick Start" guide which summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
+  - [Terminology](terminology.html): This page lists the value sets and code systems defined in this guide.
+  - [Actor Definitions](actors.html): This page defines the AU aRequesting actors, AU eRequesting Placer, AU eRequesting Filler and AU eRequesting Patient Access.
+- [Examples](examples.html): This page lists all the examples used in this guide.
+- [Support](support.html): These pages provide supporting material for implementation of AU eRequesting.
+  - [Downloads](downloads.html): This page provides links to downloadable artefacts.
+  - [License and Legal](license.html): This page outlines the license and legal requirements for material in AU eRequesting.
 
 ### Collaboration
 This guide is the product of collaborative work undertaken with participants from:

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -44,7 +44,7 @@ This guide is divided into several pages which are listed at the top of each pag
 - [Conformance](conformance.html): This page describes the set of rules to claim conformance to this guide
 - [Guidance](guidance.html): These pages list the guidance for this guide. 
   - [AU eRequesting Data for Interoperability](auereqdi.html): This page maps AUeReqDI data groups and elements to FHIR artefacts in AU eRequesting.
-  - [Relationship with other IGs](relationship.html): This page provides guidance on the relationship between AU eRequesting, AUCDI, and other implementation guides.
+  - [Relationship with other IGs](relationship.html): This page provides guidance on the relationship between AU eRequesting, AUeReqDI, and other implementation guides.
   - [AU Variance Statement](variance.html): This page documents variance from AU Base and AU Core.
   - [Future of AU eRequesting](future.html): This page outlines the approach to developing AU eRequesting and yearly update cycle.
 - [Use Cases](use-cases.html): This page describes the use cases in scope of eRequesting R1. 

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -44,7 +44,7 @@ This guide is divided into several pages which are listed at the top of each pag
 - [Conformance](conformance.html): This page describes the set of rules to claim conformance to this guide
 - [Guidance](guidance.html): These pages list the guidance for this guide. 
   - [AU eRequesting Data for Interoperability](auereqdi.html): This page maps AUeReqDI data groups and elements to FHIR artefacts in AU eRequesting.
-  - [Relationship with other IGs](relationship.html): This page provides guidance on the relationship between AU Core, AUCDI, and other implementation guides.
+  - [Relationship with other IGs](relationship.html): This page provides guidance on the relationship between AU eRequesting, AUCDI, and other implementation guides.
   - [AU Variance Statement](variance.html): This page documents variance from AU Base and AU Core.
   - [Future of AU eRequesting](future.html): This page outlines the approach to developing AU eRequesting and yearly update cycle.
 - [Use Cases](use-cases.html): This page describes the use cases in scope of eRequesting R1. 

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -43,14 +43,14 @@ This guide is divided into several pages which are listed at the top of each pag
 - [Home](index.html): This page provides the introduction and scope for this guide.
 - [Conformance](conformance.html): This page describes the set of rules to claim conformance to this guide
 - [Guidance](guidance.html): These pages list the guidance for this guide. 
-  - [AU eRequesting Data for Interoperability](auereqdi.html): This page maps the AU eRequesting resources and elements to AUeReqDI data classes and data elements.
-  - [Relationship with other HL7 AU FHIR IGs](relationship.html): This page provides guidance on the relationship between AU eRequesting and other implementation guides.
+  - [AU eRequesting Data for Interoperability](auereqdi.html): This page maps AUeReqDI data groups and elements to FHIR artefacts in AU eRequesting.
+  - [Relationship with other IGs](relationship.html): This page provides guidance on the relationship between AU Core, AUCDI, and other implementation guides.
   - [AU Variance Statement](variance.html): This page documents variance from AU Base and AU Core.
   - [Future of AU eRequesting](future.html): This page outlines the approach to developing AU eRequesting and yearly update cycle.
 - [Use Cases](use-cases.html): This page describes the use cases in scope of eRequesting R1. 
 - [FHIR Artefacts](artifacts.html): These pages provide detailed descriptions and formal definitions for all the FHIR artefacts defined in this guide.
-  - [Profiles and Extensions](profiles-and-extensions.html): This page describes the profiles and extensions that are defined in this guide to exchange quality data. Each profile page includes a narrative description and guidance, formal definition and a "Quick Start" guide which summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
-  - [Terminology](terminology.html): This page lists the value sets and code systems defined in this guide.
+  - [Profiles and Extensions](profiles-and-extensions.html): This page describes the profiles and extensions that are defined in this guide to support electronic requesting. Each profile page includes a narrative description and guidance, formal definition and a "Notes" section which summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
+  - [Terminology](terminology.html): This page lists the value sets and code systems supported in this guide.
   - [Actor Definitions](actors.html): This page defines the AU aRequesting actors, AU eRequesting Placer, AU eRequesting Filler and AU eRequesting Patient Access.
 - [Examples](examples.html): This page lists all the examples used in this guide.
 - [Support](support.html): These pages provide supporting material for implementation of AU eRequesting.

--- a/input/pagecontent/support.md
+++ b/input/pagecontent/support.md
@@ -1,0 +1,2 @@
+- [Downloads](downloads.html)
+- [License and Legal](license.html)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -67,8 +67,9 @@ pages:
   actors.md:
     title: Actor Definitions
   examples.md:
-  downloads.md:
-  license.md:
+  support.md:
+    downloads.md:
+    license.md:
   # changes.md:
     # title: Change Log
   # ImplementationGuide-hl7.fhir.au.erequesting.md:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -51,7 +51,7 @@ pages:
     future.md:
       title: Future of AU eRequesting
     relationship.md: 
-      title: Relationship with other HL7 AU FHIR IGs
+      title: Relationship with other IGs
     variance.md:
       title: AU Variance Statement
     auereqdi.md:


### PR DESCRIPTION
- Add 'Support' header and page to hold downloads and license/legal
- Add 'License and Legal' page missing from how to read
- Add missing 'AU Variance Statement' to Guidance sub page
- Removed placeholders in 'how to read' - content intended prior to ballot 

Please review with https://github.com/hl7au/au-fhir-base/pull/854 & https://github.com/hl7au/au-fhir-core/pull/220.