### PR TITLE
Simplify SR invariant (FHIR-47068)

### DIFF
--- a/input/fsh/au-erequesting-servicerequest.fsh
+++ b/input/fsh/au-erequesting-servicerequest.fsh
@@ -192,4 +192,4 @@ Description: "This profile sets minimum expectations for a ServiceRequest resour
 Invariant: au-ereq-srr-01
 Description: "Date must include at least year, month, and day"
 Severity: #error
-Expression: "$this.toString().matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}$')"
+Expression: "$this.toString().length() >= 10"

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -6,5 +6,6 @@
 This change log documents the significant updates and resolutions implemented from version 0.1.0-ballot to TBD.
 
 #### Changes in this version
+- Simplified the FHIRPath for [AU eRequesting ServiceRequest Invariant](https://build.fhir.org/ig/hl7au/au-fhir-erequesting/StructureDefinition-au-erequesting-servicerequest.html) au-ereq-srr-01 per [FHIR-47068](https://jira.hl7.org/browse/FHIR-47068)
 - New profiles: 
   - AU eRequesting Task ([FHIR-46947](https://jira.hl7.org/browse/FHIR-46947), [FHIR-46950](https://jira.hl7.org/browse/FHIR-46950), [FHIR-46956](https://jira.hl7.org/browse/FHIR-46956), [FHIR-46958](https://jira.hl7.org/browse/FHIR-46958), [FHIR-46959](https://jira.hl7.org/browse/FHIR-46959), [FHIR-47081](https://jira.hl7.org/browse/FHIR-47081), [FHIR-47082](https://jira.hl7.org/browse/FHIR-47082), [FHIR-47083](https://jira.hl7.org/browse/FHIR-47083), [FHIR-47084](https://jira.hl7.org/browse/FHIR-47084), [FHIR-47086](https://jira.hl7.org/browse/FHIR-47086), [FHIR-47102](https://jira.hl7.org/browse/FHIR-47102).

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -6,6 +6,5 @@
 This change log documents the significant updates and resolutions implemented from version 0.1.0-ballot to TBD.
 
 #### Changes in this version
-- Simplified the FHIRPath for [AU eRequesting ServiceRequest Invariant](https://build.fhir.org/ig/hl7au/au-fhir-erequesting/StructureDefinition-au-erequesting-servicerequest.html) au-ereq-srr-01 per [FHIR-47068](https://jira.hl7.org/browse/FHIR-47068)
 - New profiles: 
   - AU eRequesting Task ([FHIR-46947](https://jira.hl7.org/browse/FHIR-46947), [FHIR-46950](https://jira.hl7.org/browse/FHIR-46950), [FHIR-46956](https://jira.hl7.org/browse/FHIR-46956), [FHIR-46958](https://jira.hl7.org/browse/FHIR-46958), [FHIR-46959](https://jira.hl7.org/browse/FHIR-46959), [FHIR-47081](https://jira.hl7.org/browse/FHIR-47081), [FHIR-47082](https://jira.hl7.org/browse/FHIR-47082), [FHIR-47083](https://jira.hl7.org/browse/FHIR-47083), [FHIR-47084](https://jira.hl7.org/browse/FHIR-47084), [FHIR-47086](https://jira.hl7.org/browse/FHIR-47086), [FHIR-47102](https://jira.hl7.org/browse/FHIR-47102).


### PR DESCRIPTION
Simplified the FHIRPath expression for the "authored on" invariant on AU eRequestingServiceRequest which requires at least day precision. Done as per the ticket FHIR=47068.