### PR TITLE
ServiceRequest.requisition.type.coding fixed values to render as 1..1

### DIFF
--- a/input/fsh/au-erequesting-servicerequest.fsh
+++ b/input/fsh/au-erequesting-servicerequest.fsh
@@ -105,10 +105,10 @@ Description: "This profile sets minimum expectations for a ServiceRequest resour
 
 
 * requisition 1..1 MS
-* requisition ^type.profile = "http://hl7.org.au/fhir/StructureDefinition/au-localorderidentifier"
-* requisition.type.coding 1..1
-* requisition.type.coding.system = "http://terminology.hl7.org/CodeSystem/v2-0203"
-* requisition.type.coding.code = #PGN
+* requisition ^type.profile = $AULocalOrderIdentifier
+* requisition.type 
+  * coding 1..1    
+  * coding = $v2-0203#PGN
 * requisition ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[code].valueCode = #SHALL:populate
 * requisition ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[actor][0].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-placer"
 * requisition ^extension[http://hl7.org/fhir/StructureDefinition/obligation][1].extension[code].valueCode = #SHALL:handle


### PR DESCRIPTION
Fix for [FHIR-46975](https://jira.hl7.org/browse/FHIR-46845)

* Change to ServiceRequest.requisition.type.coding fixed values to render as 1..1