### PR TITLE
Add AU eRequesting Coverage profile (FHIR-46848)

### DIFF
--- a/input/fsh/au-erequesting-coverage.fsh
+++ b/input/fsh/au-erequesting-coverage.fsh
@@ -1,0 +1,14 @@
+Profile: AUeRequestingCoverage
+Parent: AUBaseCoverage
+Id: au-erequesting-coverage
+Title: "AU eRequesting Coverage"
+Description: "This profile sets minimum expectations for a Coverage resource that is used to record, search, and fetch information about insurance or medical plan or a payment agreement for a patient. It is based on the [AU Base Coverage](https://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-coverage.html) and identifies the additional constraints, extensions, vocabularies and value sets that **SHALL** be present in the Coverage when conforming to this profile."
+
+* ^status = #draft
+
+* ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 0
+
+* type from http://hl7.org/fhir/ValueSet/coverage-type (preferred)
+* type ^binding.extension[http://hl7.org/fhir/tools/StructureDefinition/additional-binding][0].extension[purpose].valueCode = #minimum
+* type ^binding.extension[http://hl7.org/fhir/tools/StructureDefinition/additional-binding][0].extension[valueSet].valueCanonical = "http://hl7.org.au/fhir/ereq/ValueSet/au-erequesting-coverage-type"  
+* type ^binding.extension[http://hl7.org/fhir/tools/StructureDefinition/additional-binding][0].extension[documentation].valueMarkdown = "The minimum set of codes that any conformant system SHALL support."  

--- a/input/fsh/au-erequesting-diagnosticrequest.fsh
+++ b/input/fsh/au-erequesting-diagnosticrequest.fsh
@@ -150,7 +150,7 @@ Description: "This profile sets minimum expectations for a ServiceRequest resour
 
 
 * insurance MS
-* insurance only Reference(AUBaseCoverage)
+* insurance only Reference(AUeRequestingCoverage)
 * insurance ^comment = "The provision of an insurance attribute describes a recommendation to be considered by the Filler and does not guarantee that this recommendation will be satisfied."
 * insurance ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[code].valueCode = #SHALL:populate-if-known
 * insurance ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[actor][0].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-placer"

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -13,6 +13,7 @@ This change log documents the significant updates and resolutions implemented fr
   - made the profile abstract ([FHIR-46813](https://jira.hl7.org/browse/FHIR-46813))
   - made ServiceRequest.encounter mandatory (1..1) [FHIR-47008](https://jira.hl7.org/browse/FHIR-47008)
   - added Must Support to ServiceRequest.priority [FHIR-46939](https://jira.hl7.org/browse/FHIR-46939)
+  - changed ServiceRequest.insurance reference type to the AU eRequesting Coverage [FHIR-46848](https://jira.hl7.org/browse/FHIR-46848)
   - AU eRequesting ServiceRequest profile renamed to be AU eRequesting Diagnostic Request [FHIR-46842](https://jira.hl7.org/browse/FHIR-46842)
 - Renamed AU eRequesting Patient Access actor and CapabilityStatement to be AU eRequesting Patient [FHIR-46802](https://jira.hl7.org/browse/FHIR-46802)
 

--- a/input/pagecontent/terminology.md
+++ b/input/pagecontent/terminology.md
@@ -37,7 +37,7 @@ Many value sets used in this guide are defined in the base FHIR specification, [
 |[RequestIntent](https://hl7.org/fhir/R4/valueset-request-intent.html)|[AU eRequesting Diagnostic Request](StructureDefinition-au-erequesting-diagnosticrequest.html)|FHIR|
 |[RequestStatus](https://hl7.org/fhir/R4/valueset-request-status.html)|[AU eRequesting Diagnostic Request](StructureDefinition-au-erequesting-diagnosticrequest.html)|FHIR|
 |[AU eRequesting Task Status](ValueSet-au-erequesting-task-status.html)|[AU eRequesting Task](StructureDefinition-au-erequesting-task.html)|AU eRequesting|
-|[AU eRequesting Coverage Type and Self-Pay Codes](ValueSet-au-erequesting-coverage-type.html)||AU eRequesting|
+|[AU eRequesting Coverage Type and Self-Pay Codes](ValueSet-au-erequesting-coverage-type.html)|[AU eRequesting Coverage](StructureDefinition-au-erequesting-coverage.html)|AU eRequesting|
 {:.grid}
 
 


### PR DESCRIPTION
This PR provides a fix for [FHIR-46848](https://jira.hl7.org/browse/FHIR-46848).

Changes made: 
- new profile added
- updated ServiceRequest.insurance to reference the new profile in AU eRequesting DiagnosticRequest
- updated Terminology page to link to the new profile in the Value Sets table
- updated change log