### PR TITLE
Adjust introductory text for intent of eRequesting IG

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -3,7 +3,7 @@ AU eRequesting is provided to support the use of HL7<sup>&reg;</sup> FHIR<sup>&r
 
 AU eRequesting defines the Data model and RESTful API interactions that set minimum expectations for placing and accessing electronic requests.
 
-The focus AU eRequesting Release 1 (R1) is support of pathology and medical imaging requests in community-based care provision, and developing a foundational request model that can be applied beyond diagnostic requesting. 
+The focus AU eRequesting Release 1 (R1) is support of pathology and medical imaging requests in community-based care provision, with consideration for future use beyond this scope. 
 
 
 ### Project background


### PR DESCRIPTION
[FHIR-48989](https://jira.hl7.org/browse/FHIR-48989)

On the [intro to the eRequesting IG](https://build.fhir.org/ig/hl7au/au-fhir-erequesting/#introduction), change as follows

The focus AU eRequesting Release 1 (R1) is support of pathology and medical imaging requests in community-based care provision, ~~and developing a foundational request model that can be applied beyond diagnostic requesting~~ with consideration for future use beyond this scope.
