### PR TITLE
Add Communication Request to support CopyTo

### DIFF
--- a/input/fsh/au-erequesting-communicationrequest-copyto.fsh
+++ b/input/fsh/au-erequesting-communicationrequest-copyto.fsh
@@ -1,0 +1,47 @@
+Alias: $communication-category = http://terminology.hl7.org/CodeSystem/communication-category
+
+Profile: AUeRequestingCommunicationRequestCopyTo
+Parent: CommunicationRequest
+Id: au-erequesting-communicationrequest-copyto
+Title: "AU eRequesting Communication Request CopyTo"
+Description: "AU eRequesting communication request to define a copy-to clinician."
+
+* ^status = #draft
+* ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 0
+
+* status MS
+* status = #active (exactly)
+  * ^short = "active"
+* priority MS
+* about 1.. MS
+* about only Reference (AUeRequestingPathologyRequest or AUeRequestingImagingRequest)
+  * ^short = "Diagnostic request the copyto communication is about"
+* authoredOn 1..1 MS
+* authoredOn ^short = "Date/time when communication request direction obtained"
+* sender 1.. MS
+* sender only Reference (AUCoreOrganization)
+  * ^short = "Diagnostic organization sending the communication"
+* subject 1..1 MS
+* subject only Reference (AUCorePatient)
+  * ^short = "Patient that is the subject of the Diagnostic Service"
+* requester 1.. MS
+* requester only Reference (AUCorePractitionerRole)
+  * ^short = "Individual provider requesting the communication"
+* recipient 1..1 MS
+* recipient only Reference (AUCorePractitionerRole)
+  * reference 1..
+    * ^short = "Reference to contained PractitionerRole resource.  This likely to need constraint at some point." 
+* category 1..1 MS
+* category = $communication-category#notification
+  * ^short = "notification"
+* groupIdentifier 1..1 MS
+* groupIdentifier ^type.profile = $AULocalOrderIdentifier
+* groupIdentifier.type 
+  * coding 1..1    
+  * coding = $v2-0203#PGN
+* contained ^slicing.rules = #open
+* contained ^slicing.discriminator.type = #type
+* contained ^slicing.discriminator.path = "$this"
+* contained contains 
+    recipient 1..1 MS
+* contained[recipient] only AUCorePractitionerRole

--- a/input/fsh/au-erequesting-communicationrequest-copyto.fsh
+++ b/input/fsh/au-erequesting-communicationrequest-copyto.fsh
@@ -1,47 +1,45 @@
-Alias: $communication-category = http://terminology.hl7.org/CodeSystem/communication-category
-
 Profile: AUeRequestingCommunicationRequestCopyTo
 Parent: CommunicationRequest
 Id: au-erequesting-communicationrequest-copyto
 Title: "AU eRequesting Communication Request CopyTo"
-Description: "AU eRequesting communication request to define a copy-to clinician."
+Description: "AU eRequesting communication request to define a copy-to clinician.  This will be differentiated from an urgent practitioner communication as priority may not be urgent and the requester will not be the recipient."
 
 * ^status = #draft
 * ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 0
 
-* status MS
-* status = #active (exactly)
-  * ^short = "active"
-* priority MS
-* about 1.. MS
-* about only Reference (AUeRequestingPathologyRequest or AUeRequestingImagingRequest)
-  * ^short = "Diagnostic request the copyto communication is about"
-* authoredOn 1..1 MS
-* authoredOn ^short = "Date/time when communication request direction obtained"
-* sender 1.. MS
-* sender only Reference (AUCoreOrganization)
-  * ^short = "Diagnostic organization sending the communication"
-* subject 1..1 MS
-* subject only Reference (AUCorePatient)
-  * ^short = "Patient that is the subject of the Diagnostic Service"
-* requester 1.. MS
-* requester only Reference (AUCorePractitionerRole)
-  * ^short = "Individual provider requesting the communication"
-* recipient 1..1 MS
-* recipient only Reference (AUCorePractitionerRole)
-  * reference 1..
-    * ^short = "Reference to contained PractitionerRole resource.  This likely to need constraint at some point." 
-* category 1..1 MS
-* category = $communication-category#notification
-  * ^short = "notification"
-* groupIdentifier 1..1 MS
+* groupIdentifier 1..1
 * groupIdentifier ^type.profile = $AULocalOrderIdentifier
 * groupIdentifier.type 
   * coding 1..1    
   * coding = $v2-0203#PGN
+* status = #active (exactly)
+  * ^short = "active"
+* category 1..1
+* category = http://terminology.hl7.org/CodeSystem/communication-category#notification
+  * ^short = "notification"
+* doNotPerform 0..0
+* subject 1..1
+* subject only Reference (AUCorePatient)
+  * ^short = "Patient that is the subject of the Diagnostic Request"
+* about 1..
+* about only Reference (AUeRequestingPathologyRequest or AUeRequestingImagingRequest)
+  * ^short = "Diagnostic request the copyto communication is about"
+* authoredOn 1..1
+* authoredOn ^short = "Date/time when communication request direction obtained"
+* requester 1..
+* requester only Reference (AUCorePractitionerRole)
+  * ^short = "Individual provider requesting the communication"
+* recipient 1..1
+* recipient only Reference (AUCorePractitionerRole)
+  * reference 1..
+    * ^short = "Reference to contained PractitionerRole resource.  This likely to need constraint at some point." 
+* sender 1..
+* sender only Reference (AUCoreOrganization)
+  * ^short = "Diagnostic organization sending the communication"
+
 * contained ^slicing.rules = #open
 * contained ^slicing.discriminator.type = #type
 * contained ^slicing.discriminator.path = "$this"
 * contained contains 
-    recipient 1..1 MS
+    recipient 1..1
 * contained[recipient] only AUCorePractitionerRole

--- a/input/fsh/au-erequesting-task-base.fsh
+++ b/input/fsh/au-erequesting-task-base.fsh
@@ -8,43 +8,31 @@ Description: "This base profile sets minimum expectations for derived Task resou
 * ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 0
 * ^abstract = true
 
-* groupIdentifier 1..1 MS
+* meta
+  * tag ^slicing.rules = #open
+  * tag ^slicing.discriminator.type = #value
+  * tag ^slicing.discriminator.path = "$this"
+  * tag contains 
+      eRequestingFulfillmentTask 1..1 
+  * tag[eRequestingFulfillmentTask] from AUeRequestingTaskTagFulfillment (required)
+    * ^short = "fulfillment-task | fulfillment-task-group"
+
+* groupIdentifier 1..1
 * groupIdentifier ^type.profile = $AULocalOrderIdentifier
 * groupIdentifier.type 
   * coding 1..1    
   * coding = $v2-0203#PGN
 
-* status MS
 * status from http://hl7.org.au/fhir/ereq/ValueSet/au-erequesting-task-status (required)
 
-* statusReason MS
-
-* intent MS
 * intent = #order (exactly)
 
-* priority MS 
-
-* for 1..1 MS
+* for 1..1
 * for only Reference (AUCorePatient)
 
-* requester 1..1 MS
+* requester 1..1
 * requester only Reference(AUCorePractitionerRole)
 
-* authoredOn 1..1 MS
+* authoredOn 1..1
 
-* lastModified MS
-
-* owner MS
 * owner only Reference(AUCoreOrganization)
-
-CodeSystem: AUeRequestingTaskTagCodeSystem
-Id: au-erequesting-task-tag-codesystem
-Title: "Task Tag CodeSystem"
-Description: "Tag options for labelling tasks."
-* ^status = #draft
-* ^caseSensitive = true
-* ^experimental = true
- 
-* #fulfillment-task-group "fulfillment task group"
-* #fulfillment-task "fulfillment task"
- 

--- a/input/fsh/au-erequesting-task-base.fsh
+++ b/input/fsh/au-erequesting-task-base.fsh
@@ -1,0 +1,50 @@
+Profile: AUeRequestingTaskBase
+Parent: Task
+Id: au-erequesting-task-base
+Title: "AU eRequesting Task Base"
+Description: "This base profile sets minimum expectations for derived Task resources that are used to record, search, and fetch information about a task to be performed. It is based on the [Task](https://www.hl7.org/fhir/R4/task.html) and identifies the additional constraints, extensions, vocabularies and value sets that **SHALL** be present in the derived Tasks when conforming to this profile."
+
+* ^status = #draft
+* ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 0
+* ^abstract = true
+
+* groupIdentifier 1..1 MS
+* groupIdentifier ^type.profile = $AULocalOrderIdentifier
+* groupIdentifier.type 
+  * coding 1..1    
+  * coding = $v2-0203#PGN
+
+* status MS
+* status from http://hl7.org.au/fhir/ereq/ValueSet/au-erequesting-task-status (required)
+
+* statusReason MS
+
+* intent MS
+* intent = #order (exactly)
+
+* priority MS 
+
+* for 1..1 MS
+* for only Reference (AUCorePatient)
+
+* requester 1..1 MS
+* requester only Reference(AUCorePractitionerRole)
+
+* authoredOn 1..1 MS
+
+* lastModified MS
+
+* owner MS
+* owner only Reference(AUCoreOrganization)
+
+CodeSystem: AUeRequestingTaskTagCodeSystem
+Id: au-erequesting-task-tag-codesystem
+Title: "Task Tag CodeSystem"
+Description: "Tag options for labelling tasks."
+* ^status = #draft
+* ^caseSensitive = true
+* ^experimental = true
+ 
+* #fulfillment-task-group "fulfillment task group"
+* #fulfillment-task "fulfillment task"
+ 

--- a/input/fsh/au-erequesting-task-communicationrequest.fsh
+++ b/input/fsh/au-erequesting-task-communicationrequest.fsh
@@ -9,6 +9,7 @@ Description: "AU eRequesting communication request task tracking fulfillment of 
 
 * meta.tag
   * code = #fulfillment-task
+  * system = Canonical(AUeRequestingTaskTag)
   * ^short = "fulfillment-task"
 * focus 1..1 MS
 * focus only Reference(CommunicationRequest)

--- a/input/fsh/au-erequesting-task-communicationrequest.fsh
+++ b/input/fsh/au-erequesting-task-communicationrequest.fsh
@@ -1,0 +1,18 @@
+Profile: AUeRequestingTaskCommunicationRequest
+Parent: AUeRequestingTaskBase
+Id: au-erequesting-task-communicationrequest
+Title: "AU eRequesting Communication Request Task"
+Description: "AU eRequesting communication request task tracking fulfillment of a communication request.  For example, was the communication request attempted, successful, failed."
+
+* ^status = #draft
+* ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 0
+
+* meta.tag
+  * code = #fulfillment-task
+  * ^short = "fulfillment-task"
+* focus 1..1 MS
+* focus only Reference(CommunicationRequest)
+  * ^short = "CommunicationRequest this task is the focus of"
+* partOf ..1 MS
+* partOf only Reference(AUeRequestingTaskGroup)
+  * ^short = "Task group this task is a part of"

--- a/input/fsh/au-erequesting-task-communicationrequest.fsh
+++ b/input/fsh/au-erequesting-task-communicationrequest.fsh
@@ -11,9 +11,9 @@ Description: "AU eRequesting communication request task tracking fulfillment of 
   * code = #fulfillment-task
   * system = Canonical(AUeRequestingTaskTag)
   * ^short = "fulfillment-task"
-* focus 1..1 MS
+* focus 1..1
 * focus only Reference(CommunicationRequest)
   * ^short = "CommunicationRequest this task is the focus of"
-* partOf ..1 MS
+* partOf ..1
 * partOf only Reference(AUeRequestingTaskGroup)
   * ^short = "Task group this task is a part of"

--- a/input/fsh/au-erequesting-task-group.fsh
+++ b/input/fsh/au-erequesting-task-group.fsh
@@ -9,7 +9,7 @@ Description: "This provides a grouping of tasks that are part of the same fulfil
 
 * meta.tag
   * code = #fulfillment-task-group
-  * system = Canonical(AUeRequestingTaskTagCodeSystem)
+  * system = Canonical(AUeRequestingTaskTag)
   * ^short = "fulfillment-task-group"
 
 * partOf 0..0

--- a/input/fsh/au-erequesting-task-group.fsh
+++ b/input/fsh/au-erequesting-task-group.fsh
@@ -1,0 +1,16 @@
+Profile: AUeRequestingTaskGroup
+Parent: AUeRequestingTaskBase
+Id: au-erequesting-task-group
+Title: "AU eRequesting Task Group"
+Description: "This provides a grouping of tasks that are part of the same fulfillment group.  It shares a common base profile with [AUeRequestingTaskDiagnosticRequest](StructureDefinition-au-erequesting-task-diagnosticrequest.html), namely [AUeRequestingTaskBase](StructureDefinition-au-erequesting-task-base.html) It enables more efficient discovery and processing of diagnostics orders comprising multiple tasks."
+
+* ^status = #draft
+* ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 0
+
+* meta.tag
+  * code = #fulfillment-task-group
+  * system = Canonical(AUeRequestingTaskTagCodeSystem)
+  * ^short = "fulfillment-task-group"
+
+* partOf 0..0
+* focus 0..0

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -9,7 +9,7 @@ This change log documents the significant updates and resolutions implemented fr
 - New profiles: 
   - AU eRequesting Task ([FHIR-46947](https://jira.hl7.org/browse/FHIR-46947), [FHIR-46950](https://jira.hl7.org/browse/FHIR-46950), [FHIR-46956](https://jira.hl7.org/browse/FHIR-46956), [FHIR-46958](https://jira.hl7.org/browse/FHIR-46958), [FHIR-46959](https://jira.hl7.org/browse/FHIR-46959), [FHIR-47081](https://jira.hl7.org/browse/FHIR-47081), [FHIR-47082](https://jira.hl7.org/browse/FHIR-47082), [FHIR-47083](https://jira.hl7.org/browse/FHIR-47083), [FHIR-47084](https://jira.hl7.org/browse/FHIR-47084), [FHIR-47086](https://jira.hl7.org/browse/FHIR-47086), [FHIR-47102](https://jira.hl7.org/browse/FHIR-47102).
   - AU eRequesting Coverage ([FHIR-46848](https://jira.hl7.org/browse/FHIR-46848))
-  - AU eRequesting Communication Request CopyTo and AU eRequesting Task CommunicationRequest [FHIR-](https://jira.hl7.org/browse/FHIR-)
+  - AU eRequesting Communication Request CopyTo and AU eRequesting Task CommunicationRequest [FHIR-49679](https://jira.hl7.org/browse/FHIR-49679)
 - Made the following changes to AU eRequesting ServiceRequest:
   - made the profile abstract ([FHIR-46813](https://jira.hl7.org/browse/FHIR-46813))
   - made ServiceRequest.encounter mandatory (1..1) [FHIR-47008](https://jira.hl7.org/browse/FHIR-47008)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -9,6 +9,7 @@ This change log documents the significant updates and resolutions implemented fr
 - New profiles: 
   - AU eRequesting Task ([FHIR-46947](https://jira.hl7.org/browse/FHIR-46947), [FHIR-46950](https://jira.hl7.org/browse/FHIR-46950), [FHIR-46956](https://jira.hl7.org/browse/FHIR-46956), [FHIR-46958](https://jira.hl7.org/browse/FHIR-46958), [FHIR-46959](https://jira.hl7.org/browse/FHIR-46959), [FHIR-47081](https://jira.hl7.org/browse/FHIR-47081), [FHIR-47082](https://jira.hl7.org/browse/FHIR-47082), [FHIR-47083](https://jira.hl7.org/browse/FHIR-47083), [FHIR-47084](https://jira.hl7.org/browse/FHIR-47084), [FHIR-47086](https://jira.hl7.org/browse/FHIR-47086), [FHIR-47102](https://jira.hl7.org/browse/FHIR-47102).
   - AU eRequesting Coverage ([FHIR-46848](https://jira.hl7.org/browse/FHIR-46848))
+  - AU eRequesting Communication Request CopyTo and AU eRequesting Task CommunicationRequest [FHIR-](https://jira.hl7.org/browse/FHIR-)
 - Made the following changes to AU eRequesting ServiceRequest:
   - made the profile abstract ([FHIR-46813](https://jira.hl7.org/browse/FHIR-46813))
   - made ServiceRequest.encounter mandatory (1..1) [FHIR-47008](https://jira.hl7.org/browse/FHIR-47008)


### PR DESCRIPTION
This may still need a ValueSet developed for reasonCode to more easily allow differentiation of CommunicationRequests as eRequesting will likely end up using at least 4 different kinds.