### PR TITLE
Fix CopyTo build for broken codesystem/valueset references

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -5,6 +5,7 @@ Alias: $v2-0203 = http://terminology.hl7.org/CodeSystem/v2-0203
 Alias: $coverageselfpay = http://terminology.hl7.org/CodeSystem/coverage-selfpay
 Alias: $v3-actcode = http://terminology.hl7.org/CodeSystem/v3-ActCode
 Alias: $requeststatus = http://hl7.org/fhir/request-status
+Alias: $tasktag = http://hl7.org.au/fhir/ereq/CodeSystem/au-erequesting-task-tag
 
 // AU Core profiles
 Alias: $AUCorePatient = http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient

--- a/input/fsh/codesystems/au-erequesting-task-tag.fsh
+++ b/input/fsh/codesystems/au-erequesting-task-tag.fsh
@@ -1,0 +1,22 @@
+CodeSystem: AUeRequestingTaskTag
+Id: au-erequesting-task-tag
+Title: "AU eRequesting Task Tag Codes"
+Description: "The AU eRequesting Task Tag CodeSystem provides tag values for labelling tasks in an Australian eRequesting context."
+* ^meta.profile[+] = "https://healthterminologies.gov.au/fhir/StructureDefinition/complete-code-system-4"
+* ^version = "1.0.0"
+* ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 0
+* ^publisher = "HL7 Australia"
+* ^contact.name = "HL7 Australia eRequesting Technical Design Group"
+* ^contact.telecom.system = #url
+* ^contact.telecom.value = "https://confluence.hl7.org/display/HAFWG/HL7+Australia+-+AU+eRequesting+Technical+Design+Group+Home"
+* ^contact.telecom.use = #work
+* ^date = "2025-01-28"
+* ^status = #draft
+* ^caseSensitive = true
+* ^experimental = false
+* ^versionNeeded = true
+* ^compositional = false
+* ^content = #complete
+* ^count = 2
+* #fulfillment-task "fulfillment of a task" "A tag value indicating fullfilment of a task"
+* #fulfillment-task-group "fulfillment of a group task" "A tag value indicating fullfilment of a group task"

--- a/input/fsh/valuesets/au-erequesting-task-tag-fulfillment.fsh
+++ b/input/fsh/valuesets/au-erequesting-task-tag-fulfillment.fsh
@@ -1,0 +1,13 @@
+ValueSet: AUeRequestingTaskTagFulfillment
+Id: au-erequesting-task-tag-fulfillment
+Title: "AU eRequesting Tags for Fulfillment of a Task or Group Task"
+Description: "Task tag values for labelling and differentiating fullfilment of tasks used in an Australian eRequesting context."
+* ^meta.profile[+] = "https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"
+* ^version = "1.0.0"
+* ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 0
+* ^date = "2025-01-28"
+* ^publisher = "HL7 Australia"
+* ^status = #draft 
+* ^experimental = false
+* $tasktag#fulfillment-task
+* $tasktag#fulfillment-task-group


### PR DESCRIPTION
Fixes build for MO's codesystem/valueset additions.  Copied from Task Group.  Will be same in merged build.