### PR TITLE
Add Task search parameters to Profile Notes (FHIR-48915)

### DIFF
--- a/input/includes/task_notes.md
+++ b/input/includes/task_notes.md
@@ -133,7 +133,7 @@ The following search parameters and search parameter combinations are supported.
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
    - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][code]`)
 
-    `GET [base]/Task?requester={Type/}[id]` or optionally `GET [base]/Task?parequestertient.identifier=[system|][code]`
+    `GET [base]/Task?requester={Type/}[id]` or optionally `GET [base]/Task?requester.identifier=[system|][code]`
 
     Example:
     
@@ -146,9 +146,9 @@ The following search parameters and search parameter combinations are supported.
 
 1. Combined **[`requester`](https://hl7.org/fhir/R4/task.html#search)** and **[`status`](https://hl7.org/fhir/R4/task.html#search)** search parameters
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
-  - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][code]`)
+   - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][code]`)
 
-    `GET [base]/Task?requester={Type/}[id]&status={system|}{value}` or optionally `GET [base]/Task?parequestertient.identifier=[system|][code]&status={system|}{value}`
+    `GET [base]/Task?requester={Type/}[id]&status={system|}{value}` or optionally `GET [base]/Task?requester.identifier=[system|][code]&status={system|}{value}`
 
     Example:
     

--- a/input/includes/task_notes.md
+++ b/input/includes/task_notes.md
@@ -1,0 +1,172 @@
+#### Search Parameters:
+
+The following search parameters and search parameter combinations are supported. Conformance obligations are detailed in the table above.
+
+1. **[`_id`](https://hl7.org/fhir/R4/task.html#search)** search parameter
+   - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
+ 
+    `GET [base]/Task?_id=[id]`
+
+    Example:
+    
+      1. GET [base]/Task?_id=2169591
+      1. GET [base]/Task?_id=2169591&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
+
+    *Implementation Notes:* Fetches a bundle with the requested Task, instead of just the resource itself, and allows for the inclusion of additional search parameters such as _include, _revinclude, or _lastUpdated ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id))
+
+
+1. **[`_lastUpdated`](https://hl7.org/fhir/R4/task.html#search)** search parameter
+   - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
+ 
+    `GET [base]/Task?_lastUpdated=[date]`
+
+    Example:
+    
+      1. GET [base]/Task?_lastUpdated=gt2010-10-01
+      1. GET [base]/Task?_lastUpdated=gt2010-10-01&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
+
+    *Implementation Notes:* Fetches a bundle with the requested Task, instead of just the resource itself, and allows for the inclusion of additional search parameters such as _include, _revinclude, or _lastUpdated ([how to search by date](https://build.fhir.org/search.html#date))
+
+
+1. Combined **[`_lastUpdated_`](https://hl7.org/fhir/R4/task.html#search)** and **[`status`](https://hl7.org/fhir/R4/task.html#search)** and **[`owner`](https://hl7.org/fhir/R4/task.html#search)** search parameters
+   - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
+   - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][code]`)
+
+    `GET [base]/Task?_lastUpdated=[date]&status={system|}{value}&owner={Type/}[id]` or optionally `GET [base]/Task?_lastUpdated=[date]&status={system|}{value}&owner.identifier=[system|][code]`
+
+    Example:
+    
+      1. GET [base]/Task?_lastUpdated=gt2010-10-01&status=completed&owner=https://elimbahmedicalcentre.example.com.au/orders/practitioner-identifier\|EMC1234567-1234
+      1. GET [base]/Task?_lastUpdated=gt2010-10-01&status=completed&owner.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455
+      1. GET [base]/Task?_lastUpdated=gt2010-10-01&status=completed&owner=https://elimbahmedicalcentre.example.com.au/orders/practitioner-identifier\|EMC1234567-1234&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
+
+    *Implementation Notes:* Fetches a bundle containing Task resources matching the _lastUpdated, owner and status, instead of just the resource itself, and allows for the inclusion of additional search parameters such as _include, _revinclude, or _lastUpdated ([how to search by date](https://build.fhir.org/search.html#date), [how to search by token](http://hl7.org/fhir/R4/search.html#token), [how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
+
+
+1. **[`focus`](https://hl7.org/fhir/R4/task.html#search)** search parameter
+   - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
+
+    `GET [base]/Task?focus={Type/}[id]` 
+
+    Example:
+    
+      1. GET [base]/Task?focus=AUeRequestingDiagnosticRequest/1234
+      1. GET [base]/Task?focus=AUeRequestingDiagnosticRequest/1234&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
+
+    *Implementation Notes:* Fetches a bundle containing Task resources matching the focus ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
+
+
+1. **[`group-identifier`](https://hl7.org/fhir/R4/task.html#search)** search parameter
+   - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
+
+    `GET [base]/Task?groupIdentifier={system|}{value}`
+
+    Example:
+    
+      1. GET [base]/Task?groupIdentifier=https://elimbahmedicalcentre.example.com.au/orders/task-identifier\|EMC1234567-1234 
+      1. GET [base]/Task?groupIdentifier=https://elimbahmedicalcentre.example.com.au/orders/task-identifier\|EMC1234567-1234&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
+
+    *Implementation Notes:* Fetches a bundle containing Task resources matching the group identifier ([how to search by token](http://hl7.org/fhir/R4/search.html#token))
+
+
+1. **[`owner`](https://hl7.org/fhir/R4/task.html#search)** search parameter
+   - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
+   - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][code]`)
+
+    `GET [base]/Task?owner={Type/}[id]` or optionally `GET [base]/Task?owner.identifier=[system|][code]`
+
+    Example:
+    
+      1. GET [base]/Task?owner=5678
+      1. GET [base]/Task?owner.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455
+      1. GET [base]/Task?owner=5678&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
+
+    *Implementation Notes:* Fetches a bundle containing Task resources matching the owner ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
+
+
+1. Combined **[`owner`](https://hl7.org/fhir/R4/task.html#search)** and **[`status`](https://hl7.org/fhir/R4/task.html#search)** search parameters:   
+   - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
+   - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][code]`)
+
+    `GET [base]/Task?owner={Type/}[id]&status={system|}{value}` or optionally `GET [base]/Task?owner.identifier=[system|][code]&status={system|}{value}`
+
+    Example:
+    
+      1. GET [base]/Task?owner=5678&status=completed
+      1. GET [base]/Task?owner.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455&status=completed
+      1. GET [base]/Task?owner=5678&status=completed&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
+
+    *Implementation Notes:* Fetches a bundle containing Task resources matching the owner and status ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference), [how to search by token](http://hl7.org/fhir/R4/search.html#token))
+
+
+1. **[`patient`](https://hl7.org/fhir/R4/task.html#search)** search parameter
+   - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
+   - including support for chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
+
+    `GET [base]/Task?patient={Type/}[id]` or optionally `GET [base]/Task?patient.identifier=[system|][code]`
+
+    Example:
+    
+      1. GET [base]/Task?patient=5678
+      1. GET [base]/Task?patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952
+      1. GET [base]/Task?patient=5678&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
+
+    *Implementation Notes:* Fetches a bundle containing Task resources matching the patient ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
+
+
+1. Combined **[`patient`](https://hl7.org/fhir/R4/task.html#search)** and **[`status`](https://hl7.org/fhir/R4/task.html#search)** search parameters
+   - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
+    - including support for chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
+
+   `GET [base]/Task?patient={Type/}[id]&status={system|}{value}` or optionally `GET [base]/Task?patient.identifier=[system|][code]&status={system|}{value}`
+
+    Example:
+    
+      1. GET [base]/Task?patient=5678&status=completed
+      1. GET [base]/Task?patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952&status=completed
+      1. GET [base]/Task?patient=5678&status=completed&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
+
+    *Implementation Notes:* Fetches a bundle containing Task resources matching the patient and status ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference), [how to search by token](http://hl7.org/fhir/R4/search.html#token))
+
+
+1. **[`requester`](https://hl7.org/fhir/R4/task.html#search)** search parameter
+   - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
+   - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][code]`)
+
+    `GET [base]/Task?requester={Type/}[id]` or optionally `GET [base]/Task?parequestertient.identifier=[system|][code]`
+
+    Example:
+    
+      1. GET [base]/Task?requester=5678
+      1. GET [base]/Task?requester.identifier=http://ns.electronichealth.net.au/id/medicare-provider-number\|553255
+      1. GET [base]/Task?requester=5678&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
+
+    *Implementation Notes:* Fetches a bundle containing Task resources matching the requester ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
+
+
+1. Combined **[`requester`](https://hl7.org/fhir/R4/task.html#search)** and **[`status`](https://hl7.org/fhir/R4/task.html#search)** search parameters
+   - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
+  - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][code]`)
+
+    `GET [base]/Task?requester={Type/}[id]&status={system|}{value}` or optionally `GET [base]/Task?parequestertient.identifier=[system|][code]&status={system|}{value}`
+
+    Example:
+    
+      1. GET [base]/Task?requester=5678&status=completed
+      1. GET [base]/Task?requester.identifier=http://ns.electronichealth.net.au/id/medicare-provider-number\|553255&status=completed
+      1. GET [base]/Task?requester=5678&status=completed&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
+
+    *Implementation Notes:* Fetches a bundle containing Task resources matching the requester and status ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference), [how to search by token](http://hl7.org/fhir/R4/search.html#token))
+   
+
+1. **[`status`](https://hl7.org/fhir/R4/task.html#search)** search parameter
+   - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
+
+    `GET [base]/Task?status={system|}{value}`
+
+    Example:
+    
+      1. GET [base]/Task?status=completed 
+      1. GET [base]/Task?status=completed&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
+
+    *Implementation Notes:* Fetches a bundle containing Task resources matching the status ([how to search by token](http://hl7.org/fhir/R4/search.html#token))

--- a/input/includes/task_parameters.md
+++ b/input/includes/task_parameters.md
@@ -1,0 +1,158 @@
+<table class="list" width="100%">
+<tbody>
+  <tr>
+    <th>Parameter(s)</th>
+    <th>Server Conformance</th>
+    <th>Placer Conformance</th>
+    <th>Filler Conformance</th>
+    <th>Patient Conformance</th>
+
+    <th>Type(s)</th>
+    <th>Requirements (when used alone or in combination)</th>
+  </tr>
+  <tr>
+        <td>_id</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>token</code></td>
+        <td></td>
+  </tr>
+  <tr>
+        <td>_lastUpdated</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>date</code></td>
+        <td></td>
+  </tr>
+  <tr>
+        <td>_lastUpdated+status+owner</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>date</code>+<code>token</code>+<code>reference</code></td>
+        <td></td>
+  </tr>
+  <tr>
+        <td>focus</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>reference</code></td>
+        <td></td>
+  </tr>
+  <tr>
+        <td>group-identifier</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>token</code></td>
+        <td></td>
+  </tr>
+  <tr>
+        <td>owner</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>reference</code></td>
+        <td>The same conformance rules apply to the chained search owner.identifier using HPI-O and ABN identifiers as defined in the AU Core Organization profile.</td>
+  </tr>
+  <tr>
+        <td>owner+status</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>reference</code>+<code>token</code></td>
+        <td></td>
+  </tr>
+  <tr>
+        <td>patient</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>reference</code></td>
+        <td>The same conformance rules apply to the chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
+  </tr>
+  <tr>
+        <td>patient+status</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>reference</code>+<code>token</code></td>
+        <td></td>
+  </tr>
+  <tr>
+        <td>requester</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>reference</code></td>
+        <td>The same conformance rules apply to the chained search requester.identifier using Medicare Provider Number identifier as defined in the AU Core PractitionerRole profile.</td>
+  </tr>
+  <tr>
+        <td>requester+status</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>reference</code>+<code>token</code></td>
+        <td></td>
+  </tr>
+  <tr>
+        <td>status</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>token</code></td>
+        <td></td>
+  </tr>
+  <tr>
+        <td>_include=Task:focus</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>reference</code></td>
+        <td>Modifies search results from a query using other search parameters by including the referenced focus resource</td>
+  </tr>
+  <tr>
+        <td>_include=Task:owner</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>reference</code></td>
+        <td>Modifies search results from a query using other search parameters by including the referenced focus resource</td>
+  </tr>
+  <tr>
+        <td>_include=Task:patient</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>reference</code></td>
+        <td>Modifies search results from a query using other search parameters by including the referenced focus resource</td>
+  </tr>
+  <tr>
+        <td>_include=Task:requester</td>
+        <td><b>SHALL</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><b>-</b></td>
+        <td><code>reference</code></td>
+        <td>Modifies search results from a query using other search parameters by including the referenced focus resource</td>
+  </tr>
+ </tbody>
+</table>

--- a/input/pagecontent/StructureDefinition-au-erequesting-task-diagnosticrequest-notes.md
+++ b/input/pagecontent/StructureDefinition-au-erequesting-task-diagnosticrequest-notes.md
@@ -1,0 +1,3 @@
+{% include search_parameters_intro.md -%}
+{% include task_parameters.md -%}
+{% include task_notes.md -%}

--- a/input/pagecontent/StructureDefinition-au-erequesting-task-group-notes.md
+++ b/input/pagecontent/StructureDefinition-au-erequesting-task-group-notes.md
@@ -1,0 +1,3 @@
+{% include search_parameters_intro.md -%}
+{% include task_parameters.md -%}
+{% include task_notes.md -%}

--- a/input/pagecontent/StructureDefinition-au-erequesting-task-notes.md
+++ b/input/pagecontent/StructureDefinition-au-erequesting-task-notes.md
@@ -1,0 +1,3 @@
+{% include search_parameters_intro.md -%}
+{% include task_parameters.md -%}
+{% include task_notes.md -%}


### PR DESCRIPTION
Fix for [FHIR-48915](https://jira.hl7.org/browse/FHIR-48915), apply to Task, Task Diagnostic Request, Task Group:
* Add table with search parameter and conformance in format agreed on https://build.fhir.org/ig/hl7au/au-fhir-erequesting/branches/ft_FHIR-48915-informative/StructureDefinition-au-erequesting-task.html
* Add search parameter examples 
* Noting content is already in CapabilityStatement

The content applied from [FHIR-48915](https://jira.hl7.org/browse/FHIR-48915) overlaps with the following tickets: 
* [FHIR-48330](https://jira.hl7.org/browse/FHIR-48330)
* [FHIR-47099](https://jira.hl7.org/browse/FHIR-47099)

The following tickets were superseded by [FHIR-48915](https://jira.hl7.org/browse/FHIR-48915):
* [FHIR-47089](https://jira.hl7.org/browse/FHIR-47089)
* [FHIR-47087](https://jira.hl7.org/browse/FHIR-47087)