### PR TITLE
Revert change to Coverage.type binding #187

### DIFF
--- a/input/fsh/au-erequesting-coverage.fsh
+++ b/input/fsh/au-erequesting-coverage.fsh
@@ -8,7 +8,6 @@ Description: "This profile sets minimum expectations for a Coverage resource tha
 
 * ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 0
 
-* type from http://terminology.hl7.org.au/ValueSet/au-erequesting-coverage-type (preferred)
 * type ^binding.extension[http://hl7.org/fhir/tools/StructureDefinition/additional-binding][0].extension[purpose].valueCode = #minimum
 * type ^binding.extension[http://hl7.org/fhir/tools/StructureDefinition/additional-binding][0].extension[valueSet].valueCanonical = "http://terminology.hl7.org.au/ValueSet/au-erequesting-coverage-type"  
 * type ^binding.extension[http://hl7.org/fhir/tools/StructureDefinition/additional-binding][0].extension[documentation].valueMarkdown = "The minimum set of codes that any conformant system SHALL support."  


### PR DESCRIPTION
Revert unintended change to Coverage.type binding. 

Initial commit https://github.com/hl7au/au-fhir-erequesting/commit/622b76809d368195370efcc3537d1ca8ffb2d747 re-states Coverage.type from Coverage (https://github.com/hl7au/au-fhir-erequesting/pull/97; [FHIR-46898](https://jira.hl7.org/browse/FHIR-46848)).
* type from http://hl7.org/fhir/ValueSet/coverage-type (preferred)

Subsequent commit https://github.com/hl7au/au-fhir-erequesting/commit/571ec898a858f7eb7fc4626111f0682d14cbcb1e unintentionally changed value set to the constrained eRequesting value set that is the additional binding (https://github.com/hl7au/au-fhir-erequesting/pull/112 ; [FHIR-47149](https://jira.hl7.org/browse/FHIR-47149)).
* type from http://terminology.hl7.org.au/ValueSet/au-erequesting-coverage-type (preferred)

As per MW - removing type binding to inherit from Coverage as originally intended. Noting that re-stating is not required, the inherited binding shows in diff with additional binding.