### PR TITLE
Change to Task tag & Task.partOf (FHIR-50275)

### DIFF
--- a/input/fsh/au-erequesting-task-diagnosticrequest.fsh
+++ b/input/fsh/au-erequesting-task-diagnosticrequest.fsh
@@ -7,14 +7,21 @@ Description: "This profile sets minimum expectations for a Task resource that is
 * ^status = #draft
 * ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 0
 
-* meta.tag[eRequestingFulfilmentTask]
-  * code = #fulfilment-task
-  * system = $tasktag
-  * ^short = "fulfilment-task"
+* meta.tag[eRequestingFulfilmentTask] = $tasktag#fulfilment-task
 
 * focus 1..1 MS
 * focus only Reference(AUeRequestingPathologyRequest or AUeRequestingImagingRequest)
 
-* partOf 1..1
+* partOf 1..1 MS
 * partOf only Reference(AUeRequestingTaskGroup)
   * ^short = "Task group of which this task is a part"
+* partOf ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[code].valueCode = #SHALL:populate
+* partOf ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[actor][0].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-placer"
+* partOf ^extension[http://hl7.org/fhir/StructureDefinition/obligation][1].extension[code].valueCode = #SHALL:handle
+* partOf ^extension[http://hl7.org/fhir/StructureDefinition/obligation][1].extension[actor].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-filler"
+* partOf ^extension[http://hl7.org/fhir/StructureDefinition/obligation][2].extension[code].valueCode = #SHALL:handle
+* partOf ^extension[http://hl7.org/fhir/StructureDefinition/obligation][2].extension[actor].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-server"
+* partOf ^extension[http://hl7.org/fhir/StructureDefinition/obligation][3].extension[code].valueCode = #SHALL:able-to-populate
+* partOf ^extension[http://hl7.org/fhir/StructureDefinition/obligation][3].extension[actor].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-server"
+* partOf ^extension[http://hl7.org/fhir/StructureDefinition/obligation][4].extension[code].valueCode = #SHALL:no-error
+* partOf ^extension[http://hl7.org/fhir/StructureDefinition/obligation][4].extension[actor][0].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-patient"

--- a/input/fsh/au-erequesting-task-group.fsh
+++ b/input/fsh/au-erequesting-task-group.fsh
@@ -7,9 +7,6 @@ Description: "This profile sets minimum expectations for a Task resource that is
 * ^status = #draft
 * ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 0
 
-* meta.tag[eRequestingFulfilmentTask]
-  * code = #fulfilment-task-group
-  * system = $tasktag
-  * ^short = "fulfilment-task-group"
+* meta.tag[eRequestingFulfilmentTask] = $tasktag#fulfilment-task-group
 
 * focus 0..0

--- a/input/fsh/au-erequesting-task.fsh
+++ b/input/fsh/au-erequesting-task.fsh
@@ -15,7 +15,7 @@ Description: "This profile sets minimum expectations for a Task resource that is
   * tag contains 
       eRequestingFulfilmentTask 1..1
   * tag[eRequestingFulfilmentTask] from AUeRequestingFulfilmentTaskTags (required)
-    * ^short = "fulfilment-task | fulfilment-task-group"
+
 
 * groupIdentifier 1..1 MS
 * groupIdentifier ^type.profile = $AULocalOrderIdentifier

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -10,8 +10,8 @@ This change log documents the significant updates and resolutions implemented fr
   - AU eRequesting Communication Request CopyTo ([FHIR-49807](https://jira.hl7.org/browse/FHIR-49807))
   - AU eRequesting Task ([FHIR-46947](https://jira.hl7.org/browse/FHIR-46947), [FHIR-46950](https://jira.hl7.org/browse/FHIR-46950), [FHIR-46956](https://jira.hl7.org/browse/FHIR-46956), [FHIR-46958](https://jira.hl7.org/browse/FHIR-46958), [FHIR-46959](https://jira.hl7.org/browse/FHIR-46959), [FHIR-47081](https://jira.hl7.org/browse/FHIR-47081), [FHIR-47082](https://jira.hl7.org/browse/FHIR-47082), [FHIR-47083](https://jira.hl7.org/browse/FHIR-47083), [FHIR-47084](https://jira.hl7.org/browse/FHIR-47084), [FHIR-47086](https://jira.hl7.org/browse/FHIR-47086), [FHIR-47102](https://jira.hl7.org/browse/FHIR-47102), [FHIR-49717](https://jira.hl7.org/browse/FHIR-49717))
   - AU eRequesting MHR Consent Withdrawal ([FHIR-49806](https://jira.hl7.org/browse/FHIR-49806))
-  - AU eRequesting Task Diagnostic Request ([FHIR-49718](https://jira.hl7.org/browse/FHIR-49718))
-  - AU eRequesting Task Group ([FHIR-49719](https://jira.hl7.org/browse/FHIR-49719))
+  - AU eRequesting Task Diagnostic Request ([FHIR-49718](https://jira.hl7.org/browse/FHIR-49718), [FHIR-50275](https://jira.hl7.org/browse/FHIR-50275))
+  - AU eRequesting Task Group ([FHIR-49719](https://jira.hl7.org/browse/FHIR-49719), [FHIR-50275](https://jira.hl7.org/browse/FHIR-50275))
   - AU eRequesting Coverage ([FHIR-46848](https://jira.hl7.org/browse/FHIR-46848))
 - New value sets:
   - AU eRequesting Task Status ([FHIR-47081](https://jira.hl7.org/browse/FHIR-47081))


### PR DESCRIPTION
Fix for [FHIR-50275](https://jira.hl7.org/browse/FHIR-50275)

Task tag:
* Change modeling of task tag required values in AU eRequesting Task Group and AU eRequesting Task Diagnostic Request profiles to be 'Required Pattern: At least the following' with fixed values for system and code to denote the task type.
* Additional QA fix: removed short from Task tag in AU eRequesting Task (Abstract), AU eRequesting Task Group and AU eRequesting Task Diagnostic Request. This is in line with the convention applied by AU IGs where codes available for use are not listed in the short.

Task.partOf:
* Add MS
* Add default obligations as the element is now MS
* Noting other default obligations will be added to other MS elements via https://github.com/hl7au/au-fhir-erequesting/pull/186