### PR TITLE
Add additional binding key to Coverage.type binding as per HL7 AU convention

### DIFF
--- a/input/fsh/au-erequesting-coverage.fsh
+++ b/input/fsh/au-erequesting-coverage.fsh
@@ -8,6 +8,7 @@ Description: "This profile sets minimum expectations for a Coverage resource tha
 
 * ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 0
 
+* type ^binding.extension[http://hl7.org/fhir/tools/StructureDefinition/additional-binding][0].extension[key].valueId = "adb-cov-type-min"
 * type ^binding.extension[http://hl7.org/fhir/tools/StructureDefinition/additional-binding][0].extension[purpose].valueCode = #minimum
 * type ^binding.extension[http://hl7.org/fhir/tools/StructureDefinition/additional-binding][0].extension[valueSet].valueCanonical = "http://terminology.hl7.org.au/ValueSet/au-erequesting-coverage-type"  
 * type ^binding.extension[http://hl7.org/fhir/tools/StructureDefinition/additional-binding][0].extension[documentation].valueMarkdown = "The minimum set of codes that any conformant system SHALL support."  


### PR DESCRIPTION
Related to https://github.com/hl7au/au-fhir-core/issues/340; https://github.com/orgs/hl7au/projects/10/views/1?pane=issue&itemId=113515044

HL7 AU conventions for additional binding keys documented here:https://github.com/hl7au/au-fhir-base/wiki/Additional-binding-key-conventions

Apply change to AU eRequesting Coverage. 
Resolves 2 additional binding related QA warnings.