### PR TITLE
QA Batch Fix 1

### DIFF
--- a/input/fsh/au-erequesting-diagnosticrequest.fsh
+++ b/input/fsh/au-erequesting-diagnosticrequest.fsh
@@ -37,6 +37,7 @@ Description: "This profile sets minimum expectations for a ServiceRequest resour
 
 
 * status 1..1 MS
+  * ^short = "The status of the request"
 * status from http://terminology.hl7.org.au/ValueSet/au-erequesting-request-status (required)
 * status ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[code].valueCode = #SHALL:populate
 * status ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[actor][0].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-placer"

--- a/input/includes/dev-note.md
+++ b/input/includes/dev-note.md
@@ -1,6 +1,6 @@
 <div class="note-to-contributors" markdown="1">
 
-AU eRequesting R1 is in currently in development. We are working towards a Ballot for Comment August 2024.
+AU eRequesting R1 is in currently in development. We are working towards a Ballot for Working Standard August 2025.
 
 #### Join the AU eRequesting Technical Design Group
 

--- a/input/includes/task_group_notes.md
+++ b/input/includes/task_group_notes.md
@@ -44,7 +44,7 @@ The following search parameters and search parameter combinations are supported.
     
       1. GET [base]/Task?_lastUpdated=gt2010-10-01&status=completed&owner=https://elimbahmedicalcentre.example.com.au/orders/practitioner-identifier\|EMC1234567-1234
       1. GET [base]/Task?_lastUpdated=gt2010-10-01&status=completed&owner.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455
-      1. GET [base]/Task?_lastUpdated=gt2010-10-01&status=accepted,in-progress&owner=https://elimbahmedicalcentre.example.com.au/orders/practitioner-identifier\|EMC1234567-1234&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
+      1. GET [base]/Task?_lastUpdated=gt2010-10-01&status=accepted,in-progress&owner=https://elimbahmedicalcentre.example.com.au/orders/practitioner-identifier\|EMC1234567-1234&_include=Task:patient&_include=Task:requester&_include=Task:owner
 
     *Implementation Notes:* Fetches a bundle containing Task resources matching the _lastUpdated date, owner and status ([how to search by date](https://build.fhir.org/search.html#date), [how to search by token](http://hl7.org/fhir/R4/search.html#token), [how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
 

--- a/input/pagecontent/StructureDefinition-au-erequesting-diagnosticrequest-intro.md
+++ b/input/pagecontent/StructureDefinition-au-erequesting-diagnosticrequest-intro.md
@@ -1,5 +1,3 @@
-<p class="request-for-feedback">Input is requested on the appropriateness of allowing Missing Data or Suppressed Data for all elements. Please comment by raising <a href="https://jira.hl7.org/projects/FHIR/issues">HL7 Jira Issues</a>.</p>
-
 ### Profile specific implementation guidance
 - This abstract profile provides a shared base that is common across requests for specific domains. It is not intended for direct implementation. Where a profile is defined for a specific domain that profile **SHALL** be used:
   - pathology requests **SHALL** use [AU eRequesting Pathology Request](StructureDefinition-au-erequesting-servicerequest-path.html) profile

--- a/input/pagecontent/auereqdi.md
+++ b/input/pagecontent/auereqdi.md
@@ -53,13 +53,13 @@ Column attribute descriptions are as follows:
     <td colspan="2">Urgency</td>
     <td><a href="StructureDefinition-au-erequesting-diagnosticrequest.html">AU eRequesting Diagnostic Request</a></td>
     <td>ServiceRequest.priority</td>
-    <td>This element is allowed but does not have a Must Support flag.</td>
+    <td></td>
   </tr>
    <tr>
     <td colspan="2">Service due</td>
     <td><a href="StructureDefinition-au-erequesting-diagnosticrequest.html">AU eRequesting Diagnostic Request</a></td>
     <td>ServiceRequest.occurrence[x]</td>
-    <td>This element is allowed but does not have a Must Support flag.<br><br>This element is choice between occurrenceTiming | occurrenceDateTime | occurrencePeriod.</td>
+    <td>This element is choice between occurrenceTiming | occurrenceDateTime | occurrencePeriod.</td>
   </tr>
    <tr>
     <td colspan="2">Comment</td>
@@ -126,13 +126,13 @@ Column attribute descriptions are as follows:
     <td colspan="2">Urgency</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-imag.html">AU eRequesting Imaging Request</a></td>
     <td>ServiceRequest.priority</td>
-    <td>This element is allowed but does not have a Must Support flag.</td>
+    <td></td>
   </tr>
     <tr>
     <td colspan="2">Service due</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-imag.html">AU eRequesting Imaging Request</a></td>
     <td>ServiceRequest.occurrence[x]</td>
-    <td>This element is allowed but does not have a Must Support flag.<br><br>This element is choice between occurrenceTiming | occurrenceDateTime | occurrencePeriod.</td>
+    <td>This element is choice between occurrenceTiming | occurrenceDateTime | occurrencePeriod.</td>
   </tr>
     <tr>
     <td colspan="2">Comment</td>
@@ -187,13 +187,13 @@ Column attribute descriptions are as follows:
     <td colspan="2">Urgency</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-path.html">AU eRequesting Pathology Request</a></td>
     <td>ServiceRequest.priority</td>
-    <td>This element is allowed but does not have a Must Support flag.</td>
+    <td></td>
   </tr>
     <tr>
     <td colspan="2">Service due</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-path.html">AU eRequesting Pathology Request</a></td>
     <td>ServiceRequest.occurrence[x]</td>
-    <td>This element is allowed but does not have a Must Support flag.<br><br>This element is choice between occurrenceTiming | occurrenceDateTime | occurrencePeriod.</td>
+    <td>This element is choice between occurrenceTiming | occurrenceDateTime | occurrencePeriod.</td>
   </tr>
     <tr>
     <td colspan="2">Comment</td>

--- a/input/pagecontent/auereqdi.md
+++ b/input/pagecontent/auereqdi.md
@@ -156,7 +156,7 @@ Column attribute descriptions are as follows:
     <td colspan="2">Billing guidance</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-imag.html">AU eRequesting Imaging Request</a><br><br><a href="StructureDefinition-au-erequesting-coverage.html">AU eRequesting Coverage</a></td>
     <td>ServiceRequest.insurance</td>
-    <td></td>
+    <td>ServiceRequest.insurance references a Coverage resource.</td>
   </tr>
  <tr>
     <td rowspan="10">Pathology test request</td>

--- a/input/pagecontent/auereqdi.md
+++ b/input/pagecontent/auereqdi.md
@@ -167,9 +167,9 @@ Column attribute descriptions are as follows:
   </tr>
   <tr>
     <td colspan="2">Fasting status</td>
-    <td>TBD</td>
-    <td>TBD</td>
-    <td>Work is underway in AU eRequesting to map this element. Feedback is requested on the appropriateness of using ServiceRequest.note or an extension to support fasting status. Please comment by raising <a href="https://jira.hl7.org/projects/FHIR/issues">HL7 Jira Issues</a>.</td>
+    <td><a href="StructureDefinition-au-erequesting-servicerequest-path.html">AU eRequesting Pathology Request</a></td>
+    <td>ServiceRequest.extension:fastingPrecondition</td>
+    <td></td>
   </tr>
     <tr>
     <td colspan="2">Clinical indication</td>

--- a/input/pagecontent/auereqdi.md
+++ b/input/pagecontent/auereqdi.md
@@ -82,7 +82,7 @@ Column attribute descriptions are as follows:
    <tr>
     <td colspan="2">Billing guidance</td>
     <td><a href="StructureDefinition-au-erequesting-diagnosticrequest.html">AU eRequesting Diagnostic Request</a><br><br><a href="StructureDefinition-au-erequesting-coverage.html">AU eRequesting Coverage</a></td>
-    <td>ServiceRequest.insurance</td>
+    <td>ServiceRequest.insurance<br><br>Coverage</td>
     <td>ServiceRequest.insurance references a Coverage resource.</td>
   </tr>
   <tr>
@@ -155,7 +155,7 @@ Column attribute descriptions are as follows:
     <tr>
     <td colspan="2">Billing guidance</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-imag.html">AU eRequesting Imaging Request</a><br><br><a href="StructureDefinition-au-erequesting-coverage.html">AU eRequesting Coverage</a></td>
-    <td>ServiceRequest.insurance</td>
+    <td>ServiceRequest.insurance<br><br>Coverage</td>
     <td>ServiceRequest.insurance references a Coverage resource.</td>
   </tr>
  <tr>

--- a/input/pagecontent/conformance.md
+++ b/input/pagecontent/conformance.md
@@ -62,14 +62,10 @@ Servers that are conformant to the AU eRequesting API declare conformance by:
 ### Exchange Format Support
 In FHIR, resources are exchanged in the following formats: JSON, XML, and Turtle. Due to the popularity of JavaScript-based apps and ease of usage with JSON, the most popular exchange format for REST-styled APIs is JSON. 
 
-<p class="request-for-feedback">Input is requested on the appropriateness of mandating JSON or XML. Please comment by raising <a href="https://jira.hl7.org/projects/FHIR/issues">HL7 Jira Issues</a>.</p>
-
 ### Mandatory Elements
 Mandatory elements are elements with minimum cardinality > 0. When an element is mandatory, the data is expected to always be present. 
 
 The convention in this guide is to mark all mandatory elements as *Must Support* unless they are nested under an optional element.
-
-<p class="request-for-feedback">Input is requested on the appropriateness of allowing Missing Data or Suppressed Data for all elements. Please comment by raising <a href="https://jira.hl7.org/projects/FHIR/issues">HL7 Jira Issues</a>.</p>
 
 ### Must Support and Obligation
 Labelling an element *[Must Support](https://www.hl7.org/fhir/conformance-rules.html#mustSupport)* means that systems that produce or consume resources **SHALL** provide support for the element in some meaningful way. The FHIR standard does not define exactly what 'meaningful' support for an element means, but indicates that a profile **SHALL** make clear exactly what kind of support is required when an element is labelled as *Must Support*.

--- a/input/resources/au-erequesting-placer.xml
+++ b/input/resources/au-erequesting-placer.xml
@@ -99,7 +99,6 @@
         <definition value="http://hl7.org.au/fhir/ereq/SearchParameter/au-erequesting-servicerequest-supporting-info"/>
         <type value="reference"/>
       </searchParam>
-      <!--
       <searchParam>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="MAY"/>
@@ -108,7 +107,6 @@
         <definition value="http://hl7.org/fhir/SearchParameter/ServiceRequest-requisition"/>
         <type value="token"/>
       </searchParam>
-      -->
       <searchInclude value="ServiceRequest:patient">
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
         <valueCode value="MAY"/>


### PR DESCRIPTION
1. Fix reference to ballot and year in dev-note on index page to 'Working Standard' and '2025'
2. Add short to ServiceRequest.status - short from base ServiceRequest resource contained codes that are not in the constrained value set bound to status. Added short to override.
3. https://github.com/hl7au/au-fhir-erequesting/issues/233 - remove '_include=Task:focus' from example 3. Focus is prohibited in Task Group.
4. Update mapping for Fasting Status on AUeReqDI page (as per MW) based on agreed [fasting status proposal](https://confluence.hl7.org/spaces/HAFWG/pages/320996926/Fasting+Timing+and+Quantity+Feature+Proposals).
5. Remove outdated comments on priority/occurrence regarding elements not being MS as they are MS in current profiles https://github.com/hl7au/au-fhir-erequesting/issues/169
6. Remove stu notes from Conformance page and AU eReq Diagnostic Request profile.
7. Reinstate requisition search parameter for Placer actor, incorrectly commented out of CapabilityStatement.