### PR TITLE
Add supporting-info search parameter to the AU Variance statement

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -78,6 +78,3 @@ This change log documents the significant updates and resolutions implemented fr
   - added supporting-info search parameter and _include support for ServiceRequest:supporting-info as MAY for the ServiceRequest resource type [FHIR-51005](https://jira.hl7.org/browse/FHIR-51005)
   - changed the conformance requirement from SHOULD to MAY for _include search parameters ServiceRequest:patient, ServiceRequest:requester and ServiceRequest:encounter [FHIR-50976](https://jira.hl7.org/browse/FHIR-50976)
 - Updated AU eRequesting ValueSet resources to remove conformance to HL7 International <a href="http://hl7.org/fhir/StructureDefinition/shareablevalueset">ShareableValueSet</a> and instead claim conformance to <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"> NCTS Composed ValueSet</a> (<a href="https://jira.hl7.org/browse/FHIR-47149">FHIR-47149</a>).
-- Made the following changes in AU Variance Statement:
-  - added supporting-info search parameter to variance from AU Base
-  - added AU eRequesting Display Sequence and AU eRequesting Diagnostic Request extensions to variance from AU Base

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -78,3 +78,6 @@ This change log documents the significant updates and resolutions implemented fr
   - added supporting-info search parameter and _include support for ServiceRequest:supporting-info as MAY for the ServiceRequest resource type [FHIR-51005](https://jira.hl7.org/browse/FHIR-51005)
   - changed the conformance requirement from SHOULD to MAY for _include search parameters ServiceRequest:patient, ServiceRequest:requester and ServiceRequest:encounter [FHIR-50976](https://jira.hl7.org/browse/FHIR-50976)
 - Updated AU eRequesting ValueSet resources to remove conformance to HL7 International <a href="http://hl7.org/fhir/StructureDefinition/shareablevalueset">ShareableValueSet</a> and instead claim conformance to <a href="https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"> NCTS Composed ValueSet</a> (<a href="https://jira.hl7.org/browse/FHIR-47149">FHIR-47149</a>).
+- Made the following changes in AU Variance Statement:
+  - added supporting-info search parameter to variance from AU Base
+  - added AU eRequesting Display Sequence and AU eRequesting Diagnostic Request extensions to variance from AU Base

--- a/input/pagecontent/variance.md
+++ b/input/pagecontent/variance.md
@@ -6,7 +6,11 @@ HL7 Australia published FHIR implementation guides are required to follow specif
 - **SHALL** include an AU Variance Statement page
 
 ### Variance from AU Base
-This implementation guide has no variance (i.e. fully compliant) from AU Base FHIR Implementation Guide version 5.0.1-ci-build ([current](https://build.fhir.org/ig/hl7au/au-fhir-base/)).
+This implementation guide has the following variance from AU Base FHIR Implementation Guide version 5.0.1-ci-build ([current](https://build.fhir.org/ig/hl7au/au-fhir-base/)):
+
+#### Additionally defined Search Parameter
+This implementation guide defines an additional search parameter for the ServiceRequest resource that is not present in AU Base:
+- [supporting-info](SearchParameter-au-erequesting-servicerequest-supporting-info.html)
 
 #### Additionally Profiled Resources
 This implementation guide profiles the following resources that are not profiled in AU Base:

--- a/input/pagecontent/variance.md
+++ b/input/pagecontent/variance.md
@@ -55,3 +55,8 @@ This implementation guide profiles the following resources that are not profiled
   - [AU eRequesting Task Diagnostic Request](StructureDefinition-au-erequesting-task-diagnosticrequest.html)
   - [AU eRequesting Task Group](StructureDefinition-au-erequesting-task-group.html)
   - [AU eRequesting Task Communication Request](StructureDefinition-au-erequesting-task-communicationrequest.html)
+- Extension
+  - [AU eRequesting Display Sequence](StructureDefinition-au-erequesting-displaysequence.html)
+  - [AU eRequesting Fasting Precondition](StructureDefinition-au-erequesting-fastingprecondition.html)
+- SearchParameter
+  - [supporting-info](SearchParameter-au-erequesting-servicerequest-supporting-info.html)

--- a/input/pagecontent/variance.md
+++ b/input/pagecontent/variance.md
@@ -6,7 +6,7 @@ HL7 Australia published FHIR implementation guides are required to follow specif
 - **SHALL** include an AU Variance Statement page
 
 ### Variance from AU Base
-This implementation guide has no variance (i.e. fully compliant) from AU Base FHIR Implementation Guide version 5.0.1-ci-build ([current](https://build.fhir.org/ig/hl7au/au-fhir-base/)):
+This implementation guide has no variance (i.e. fully compliant) from AU Base FHIR Implementation Guide version 6.0.0-ci-build ([current](https://build.fhir.org/ig/hl7au/au-fhir-base/)):
 
 #### Additionally Profiled Resources
 This implementation guide profiles the following resources that are not profiled in AU Base:
@@ -31,7 +31,7 @@ This implementation guide profiles the following resources that are not profiled
   - [supporting-info](SearchParameter-au-erequesting-servicerequest-supporting-info.html)
 
 ### Variance from AU Core
-This implementation guide has no variance (i.e. fully compliant) from AU Core FHIR Implementation Guide version 5.0.1-ci-build ([current](https://build.fhir.org/ig/hl7au/au-fhir-core/)).
+This implementation guide has no variance (i.e. fully compliant) from AU Core FHIR Implementation Guide version 2.0.0-ci-build ([current](https://build.fhir.org/ig/hl7au/au-fhir-core/)).
 
 #### Additionally Profiled Resources
 This implementation guide profiles the following resources that are not profiled in AU Core:

--- a/input/pagecontent/variance.md
+++ b/input/pagecontent/variance.md
@@ -6,11 +6,7 @@ HL7 Australia published FHIR implementation guides are required to follow specif
 - **SHALL** include an AU Variance Statement page
 
 ### Variance from AU Base
-This implementation guide has the following variance from AU Base FHIR Implementation Guide version 5.0.1-ci-build ([current](https://build.fhir.org/ig/hl7au/au-fhir-base/)):
-
-#### Additionally defined Search Parameter
-This implementation guide defines an additional search parameter for the ServiceRequest resource that is not present in AU Base:
-- [supporting-info](SearchParameter-au-erequesting-servicerequest-supporting-info.html)
+This implementation guide has no variance (i.e. fully compliant) from AU Base FHIR Implementation Guide version 5.0.1-ci-build ([current](https://build.fhir.org/ig/hl7au/au-fhir-base/)):
 
 #### Additionally Profiled Resources
 This implementation guide profiles the following resources that are not profiled in AU Base:
@@ -28,6 +24,11 @@ This implementation guide profiles the following resources that are not profiled
   - [AU eRequesting Task Diagnostic Request](StructureDefinition-au-erequesting-task-diagnosticrequest.html)
   - [AU eRequesting Task Group](StructureDefinition-au-erequesting-task-group.html)
   - [AU eRequesting Task Communication Request](StructureDefinition-au-erequesting-task-communicationrequest.html)
+- Search Parameters
+  - [supporting-info](SearchParameter-au-erequesting-servicerequest-supporting-info.html) in [AU eRequesting Diagnostic Request](StructureDefinition-au-erequesting-diagnosticrequest.html)
+- Extensions
+  - [AU eRequesting Display Sequence](StructureDefinition-au-erequesting-displaysequence.html) in [AU eRequesting Diagnostic Request](StructureDefinition-au-erequesting-diagnosticrequest.html)
+  - [AU eRequesting Fasting Precondition](StructureDefinition-au-erequesting-fastingprecondition.html) in [AU eRequesting Diagnostic Request](StructureDefinition-au-erequesting-diagnosticrequest.html)
 
 ### Variance from AU Core
 This implementation guide has no variance (i.e. fully compliant) from AU Core FHIR Implementation Guide version 5.0.1-ci-build ([current](https://build.fhir.org/ig/hl7au/au-fhir-core/)).


### PR DESCRIPTION
- Made the following changes in AU Variance Statement:
  - added supporting-info search parameter to variance from AU Base
  - added AU eRequesting Display Sequence and AU eRequesting Diagnostic Request extensions to variance from AU Base