### PR TITLE
Drafted Introduction section Scope of AU eRequesting Release 1

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -45,7 +45,7 @@ Full use case descriptions are available in [AU eRequesting Use Cases](https://b
 #### Out-of-Scope Scenarios
 
 The following diagnostic request scenarios are outside the scope of this release:
-- Handling of diagnostic results
+- Handling of diagnostic reports
 - Inpatient and inter-hospital workflows
 - Sendaway workflows where specimens are referred to another laboratory
 - Specimen collection processes

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -23,7 +23,7 @@ The [Australian eRequesting Data for Interoperability (AUeReqDI)](https://sparke
 
 The scope of AU eRequesting Release 1 is the support of pathology and medical imaging requests in community-based care provision.
 
-#### In-Scope Scenarios
+#### In-scope scenarios
 
 The following diagnostic request scenarios are in scope for Release 1:
 
@@ -42,7 +42,7 @@ The following diagnostic request scenarios are in scope for Release 1:
 
 Full use case descriptions are available in [AU eRequesting Use Cases](https://build.fhir.org/ig/hl7au/au-fhir-erequesting/use-cases.html)
 
-#### Out-of-Scope Scenarios
+#### Out-of-scope scenarios
 
 The following diagnostic request scenarios are outside the scope of this release:
 - Handling of diagnostic reports
@@ -51,7 +51,7 @@ The following diagnostic request scenarios are outside the scope of this release
 - Specimen collection processes
 - Appointment scheduling and booking
 
-#### Technical Scope
+#### Technical scope
 
 AU eRequesting Release 1 defines the foundational FHIR data model and RESTful API interactions for exchanging diagnostic service requests.
 
@@ -60,7 +60,7 @@ This includes:
 - System actors that represent key system roles within diagnostic requesting workflows  
 - Capability statements that specify expected FHIR interactions, supported profiles, and search capabilities for each actor  
 
-#### Aspects Not Included in This Release
+#### Aspects not included in this release
 
 As Release 1 focuses on defining a foundational FHIR data model and RESTful API interactions, several aspects are intentionally out of scope. This approach supports alignment and adoption by emerging diagnostic requesting solutions, while maintaining flexibility to respond to evolving national policy directions and infrastructure considerations in future releases or downstream implementation guides.
 

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -27,46 +27,32 @@ The scope of AU eRequesting Release 1 is the support of pathology and medical im
 
 The following diagnostic request scenarios are in scope for Release 1:
 
-- Electronic requests for pathology and medical imaging services, with support for patient choice:
+- Electronic requests for pathology and medical imaging services, with support for patient choice via assigned or unassigned requests:
   * From community-based clinicians to:
     + Private diagnostic service providers  
     + Public hospital-based diagnostic service providers  
     + Interstate diagnostic service providers  
   * From hospital outpatient services to community-based diagnostic providers  
-  * Patient choice is supported through:
-    + Unassigned requests, where a request is made for diagnostic services and no provider is specified. The patient chooses their preferred provider to receive the service.
-    + Assigned requests, where the request is assigned to a preferred diagnostic provider at the time of the request. The patient may still elect to receive the service elsewhere.
-
+  
 - Request fulfilment tracking:
   * Systems can monitor the status and progression of requests throughout the fulfilment process  
 
-Full use case descriptions are available in [AU eRequesting Use Cases](https://build.fhir.org/ig/hl7au/au-fhir-erequesting/use-cases.html)
+See [AU eRequesting Use Cases](use-cases.html) for complete use case descriptions. 
 
-#### Out-of-scope scenarios
+#### Out of scope
 
-The following diagnostic request scenarios are outside the scope of this release:
+The following diagnostic request scenarios are outside the scope of Release 1:
 - Handling of diagnostic reports
 - Inpatient and inter-hospital workflows
 - Sendaway workflows where specimens are referred to another laboratory
 - Specimen collection processes
 - Appointment scheduling and booking
 
-#### Technical scope
+As Release 1 focuses on defining a foundational FHIR data model and RESTful API interactions, several technical aspects are intentionally out of scope. This approach supports alignment and adoption by emerging diagnostic requesting solutions, while maintaining flexibility to respond to evolving national policy directions and infrastructure considerations in future releases or downstream implementation guides.
 
-AU eRequesting Release 1 defines the foundational FHIR data model and RESTful API interactions for exchanging diagnostic service requests.
-
-This includes:
-- FHIR profiles that specify the structure and content of diagnostic requests, fulfilment tracking, and associated clinical and administrative information  
-- System actors that represent key system roles within diagnostic requesting workflows  
-- Capability statements that specify expected FHIR interactions, supported profiles, and search capabilities for each actor  
-
-#### Aspects not included in this release
-
-As Release 1 focuses on defining a foundational FHIR data model and RESTful API interactions, several aspects are intentionally out of scope. This approach supports alignment and adoption by emerging diagnostic requesting solutions, while maintaining flexibility to respond to evolving national policy directions and infrastructure considerations in future releases or downstream implementation guides.
-
-The following aspects were not considered priorities for the scope of Release 1:
+The following technical aspects were not considered priority for the scope of Release 1:
 - Authentication, authorisation, and auditing  
-- Barcodes or QR codes definition and format  
+- Barcode or QR code definition and format  
 - Provider discovery and federated resource location patterns  
 - Claiming of diagnostic requests by fillers  
 - Supporting information for ServiceRequests not yet defined, for example, Adverse Reaction Risk Summary or Problem/Diagnosis Summary  

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -21,38 +21,55 @@ The [Australian eRequesting Data for Interoperability (AUeReqDI)](https://sparke
 
 ### Scope of AU eRequesting Release 1
 
-The scope of AU eRequesting Release 1 is the support of pathology and medical imaging requests in community-based care provision. This release supports the following use cases:
-- Electronic requests for pathology and medical imaging services:
-    * From community-based clinicians to:
-         + Private diagnostic service providers
-         + Public hospital-based diagnostic service providers
-         + Interstate diagnostic service providers
-     * From hospital outpatient services to community-based diagnostic providers.
-- Patient choice:
-    * Unassigned requests, where a request is made for diagnostic services and no provider is specified. The patient chooses their preferred provider to receive the service.
-    * Assigned requests, where the request is assigned to a preferred diagnostic provider at the time of the request. The patient may still elect to receive the service elsewhere.
+The scope of AU eRequesting Release 1 is the support of pathology and medical imaging requests in community-based care provision.
+
+#### In-Scope Scenarios
+
+The following diagnostic request scenarios are in scope for Release 1:
+
+- Electronic requests for pathology and medical imaging services, with support for patient choice:
+  * From community-based clinicians to:
+    + Private diagnostic service providers  
+    + Public hospital-based diagnostic service providers  
+    + Interstate diagnostic service providers  
+  * From hospital outpatient services to community-based diagnostic providers  
+  * Patient choice is supported through:
+    + Unassigned requests, where a request is made for diagnostic services and no provider is specified. The patient chooses their preferred provider to receive the service.
+    + Assigned requests, where the request is assigned to a preferred diagnostic provider at the time of the request. The patient may still elect to receive the service elsewhere.
+
 - Request fulfilment tracking:
-    * Systems can monitor the status and progression of requests throughout the fulfilment process.
+  * Systems can monitor the status and progression of requests throughout the fulfilment process  
+
+Full use case descriptions are available in [AU eRequesting Use Cases](https://build.fhir.org/ig/hl7au/au-fhir-erequesting/use-cases.html)
+
+#### Out-of-Scope Scenarios
 
 The following diagnostic request scenarios are outside the scope of this release:
 - Handling of diagnostic results
 - Inpatient and inter-hospital workflows
 - Sendaway workflows where specimens are referred to another laboratory
-- Sample/specimen collection processes
+- Specimen collection processes
 - Appointment scheduling and booking
 
-AU eRequesting Release 1 establishes a foundation for the structured and interoperable exchange of diagnostic service requests using FHIR. It supports the communication of electronic requests between requesting systems and service provider systems using standardised FHIR data elements and RESTful API interactions, defined through:
-- FHIR profiles that specify the structure and content of diagnostic requests, fulfilment tracking, and associated clinical and administrative information
-- System actors that represent key system roles within diagnostic requesting workflows
-- Capability statements that specify expected FHIR interactions, supported profiles, and search capabilities for each actor
+#### Technical Scope
 
-With its focus on establishing a foundational FHIR data model and RESTful API interactions, Release 1 leaves a number of aspects out of scope. This approach supports alignment and adoption by emerging diagnostic requesting solutions, while maintaining flexibility to respond to evolving national policy directions and infrastructure considerations in future releases or downstream implementation guides. The following aspects were not considered priorities for the scope of Release 1:
-- Authentication, authorization, and auditing
-- Barcodes/QR codes definition and format
-- Provider and resource location patterns
-- Claiming orders
-- Additional supporting information
+AU eRequesting Release 1 defines the foundational FHIR data model and RESTful API interactions for exchanging diagnostic service requests.
 
+This includes:
+- FHIR profiles that specify the structure and content of diagnostic requests, fulfilment tracking, and associated clinical and administrative information  
+- System actors that represent key system roles within diagnostic requesting workflows  
+- Capability statements that specify expected FHIR interactions, supported profiles, and search capabilities for each actor  
+
+#### Aspects Not Included in This Release
+
+As Release 1 focuses on defining a foundational FHIR data model and RESTful API interactions, several aspects are intentionally out of scope. This approach supports alignment and adoption by emerging diagnostic requesting solutions, while maintaining flexibility to respond to evolving national policy directions and infrastructure considerations in future releases or downstream implementation guides.
+
+The following aspects were not considered priorities for the scope of Release 1:
+- Authentication, authorisation, and auditing  
+- Barcodes or QR codes definition and format  
+- Provider discovery and federated resource location patterns  
+- Claiming of diagnostic requests by fillers  
+- Supporting information for ServiceRequests not yet defined, for example, Adverse Reaction Risk Summary or Problem/Diagnosis Summary  
 
 ### Dependencies
 

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -18,6 +18,42 @@ The [Australian eRequesting Data for Interoperability (AUeReqDI)](https://sparke
 
 {% include dev-note.md -%}
 
+
+### Scope of AU eRequesting Release 1
+
+The scope of AU eRequesting Release 1 is the support of pathology and medical imaging requests in community-based care provision. This release supports the following use cases:
+- Electronic requests for pathology and medical imaging services:
+    * From community-based clinicians to:
+         + Private diagnostic service providers
+         + Public hospital-based diagnostic service providers
+         + Interstate diagnostic service providers
+     * From hospital outpatient services to community-based diagnostic providers.
+- Patient choice:
+    * Unassigned requests, where a request is made for diagnostic services and no provider is specified. The patient chooses their preferred provider to receive the service.
+    * Assigned requests, where the request is assigned to a preferred diagnostic provider at the time of the request. The patient may still elect to receive the service elsewhere.
+- Request fulfilment tracking:
+    * Systems can monitor the status and progression of requests throughout the fulfilment process.
+
+The following diagnostic request scenarios are outside the scope of this release:
+- Handling of diagnostic results
+- Inpatient and inter-hospital workflows
+- Sendaway workflows where specimens are referred to another laboratory
+- Sample/specimen collection processes
+- Appointment scheduling and booking
+
+AU eRequesting Release 1 establishes a foundation for the structured and interoperable exchange of diagnostic service requests using FHIR. It supports the communication of electronic requests between requesting systems and service provider systems using standardised FHIR data elements and RESTful API interactions, defined through:
+- FHIR profiles that specify the structure and content of diagnostic requests, fulfilment tracking, and associated clinical and administrative information
+- System actors that represent key system roles within diagnostic requesting workflows
+- Capability statements that specify expected FHIR interactions, supported profiles, and search capabilities for each actor
+
+With its focus on establishing a foundational FHIR data model and RESTful API interactions, Release 1 leaves a number of aspects out of scope. This approach supports alignment and adoption by emerging diagnostic requesting solutions, while maintaining flexibility to respond to evolving national policy directions and infrastructure considerations in future releases or downstream implementation guides. The following aspects were not considered priorities for the scope of Release 1:
+- Authentication, authorization, and auditing
+- Barcodes/QR codes definition and format
+- Provider and resource location patterns
+- Claiming orders
+- Additional supporting information
+
+
 ### Dependencies
 
 {% include dependency-table.xhtml %}


### PR DESCRIPTION
Added Scope of AU eRequesting Release 1 to IG. 

AU eRequesting R1 Scope was discussed in [2024-01-18 AU eRequesting TDG Agenda/Minutes](https://confluence.hl7.org/spaces/HAFWG/pages/210076086/2024-01-18+AU+eRequesting+TDG+Agenda+Minutes) and is documented in [AU eRequesting TDG - R1 Scope](https://confluence.hl7.org/pages/viewpage.action?pageId=288074718)

Out of scope aspects were also endorsed by the AU eRequesting TDG in [FHIR-51082](https://jira.hl7.org/browse/FHIR-51082) 


