### PR TITLE
Conformance changes for supporting-info SearchParam and Filler update (FHIR-51253, FHIR-51406)

### DIFF
--- a/input/includes/servicerequest_parameters.md
+++ b/input/includes/servicerequest_parameters.md
@@ -29,7 +29,7 @@
   </tr>
   <tr>
         <td>supporting-info</td>
-        <td><b>SHOULD</b></td>
+        <td><b>SHALL</b></td>
         <td><b>MAY</b></td>
         <td><b>MAY</b></td>
         <td><b>MAY</b></td>
@@ -55,8 +55,8 @@
         <td>Modifies search results from a query using other search parameters by including the referenced focus resource</td>
   </tr>
   <tr>
-        <td>_include=ServiceRequest:encounter</td>
-        <td><b>SHOULD</b></td>
+        <td>_include=ServiceRequest:supporting-info</td>
+        <td><b>SHALL</b></td>
         <td><b>MAY</b></td>
         <td><b>MAY</b></td>
         <td><b>MAY</b></td>
@@ -64,7 +64,7 @@
         <td>Modifies search results from a query using other search parameters by including the referenced focus resource</td>
   </tr>
   <tr>
-        <td>_include=ServiceRequest:supporting-info</td>
+        <td>_include=ServiceRequest:encounter</td>
         <td><b>SHOULD</b></td>
         <td><b>MAY</b></td>
         <td><b>MAY</b></td>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -67,6 +67,7 @@ This change log documents the significant updates and resolutions implemented fr
   - added _include support for PractitionerRole:practitioner and PractitionerRole:organization as SHALL for the PractitionerRole resource type [FHIR-48934](https://jira.hl7.org/browse/FHIR-48934), [FHIR-47145](https://jira.hl7.org/browse/FHIR-47145)
   - added the following Task search parameters as SHALL: group-identifier, owner, patient, requester, focus, status, _lastUpdated, patient+status, owner+status, requester+status, _lastUpdated+status+owner, patient.identifier, owner.identifier, requester.identifier, Task:patient, Task:requester, Task:owner and Task:focus [FHIR-48915](https://jira.hl7.org/browse/FHIR-48915)
   - added supporting-info search parameter and _include support for ServiceRequest:supporting-info as SHOULD for the ServiceRequest resource type [FHIR-51005](https://jira.hl7.org/browse/FHIR-51005)
+  - changed supporting-info search parameter and _include support for ServiceRequest:supporting-info from SHOULD to SHALL for the ServiceRequest resource type [FHIR-51253](https://jira.hl7.org/browse/FHIR-51253)
   - changed the resource conformance requirement from SHOULD to SHALL for the following resource types: Coverage, Encounter, Organization, Practitioner and PractitionerRole [FHIR-50976](https://jira.hl7.org/browse/FHIR-50976)
 - Made the following changes in AU eRequesting Placer CapabilityStatement:
   - added supporting-info search parameter and _include support for ServiceRequest:supporting-info as MAY for the ServiceRequest resource type [FHIR-51005](https://jira.hl7.org/browse/FHIR-51005)
@@ -74,6 +75,7 @@ This change log documents the significant updates and resolutions implemented fr
 - Made the following changes in AU eRequesting Filler CapabilityStatement:
   - added supporting-info search parameter and _include support for ServiceRequest:supporting-info as MAY for the ServiceRequest resource type [FHIR-51005](https://jira.hl7.org/browse/FHIR-51005)
   - changed the conformance requirement from SHOULD to MAY for _include search parameters ServiceRequest:patient, ServiceRequest:requester and ServiceRequest:encounter [FHIR-50976](https://jira.hl7.org/browse/FHIR-50976)
+  - added update interaction as SHALL for Task resource type [FHIR-51406](https://jira.hl7.org/browse/FHIR-51406)
 - Made the following changes in AU eRequesting Patient CapabilityStatement:
   - added supporting-info search parameter and _include support for ServiceRequest:supporting-info as MAY for the ServiceRequest resource type [FHIR-51005](https://jira.hl7.org/browse/FHIR-51005)
   - changed the conformance requirement from SHOULD to MAY for _include search parameters ServiceRequest:patient, ServiceRequest:requester and ServiceRequest:encounter [FHIR-50976](https://jira.hl7.org/browse/FHIR-50976)

--- a/input/resources/au-erequesting-filler.xml
+++ b/input/resources/au-erequesting-filler.xml
@@ -748,6 +748,12 @@
       <documentation value="Fillers **SHALL** support the Task resource, the AU eRequesting profiles, and the conformance expectations for the Task resource.&#xA;&#xA;The Filler **MAY** support the `_include` parameter for `Task:patient`, `Task:requester`, `Task:owner`, `Task:focus`."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHOULD"/>
         </extension>
         <code value="read"/>

--- a/input/resources/au-erequesting-server.xml
+++ b/input/resources/au-erequesting-server.xml
@@ -58,7 +58,7 @@
           <valueCode value="SHOULD"/>
         </extension>
       </supportedProfile>
-      <documentation value="Servers **SHALL** support the ServiceRequest resource, at least one AU eRequesting Diagnostic Request profile, and the conformance expectations for the ServiceRequest resource.&#xa;&#xa;The Server **SHALL** support the `_include` parameter for `ServiceRequest:patient` and `ServiceRequest:requester`, and **SHOULD** support the `_include` parameter for `ServiceRequest:encounter` and `ServiceRequest:supporting-info`."/>
+      <documentation value="Servers **SHALL** support the ServiceRequest resource, at least one AU eRequesting Diagnostic Request profile, and the conformance expectations for the ServiceRequest resource.&#xa;&#xa;The Server **SHALL** support the `_include` parameter for `ServiceRequest:patient`, `ServiceRequest:requester` and `ServiceRequest:supporting-info`, and **SHOULD** support the `_include` parameter for `ServiceRequest:encounter`."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHALL"/>
@@ -100,7 +100,7 @@
       </searchInclude>
       <searchInclude value="ServiceRequest:supporting-info">
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-        <valueCode value="SHOULD"/>
+        <valueCode value="SHALL"/>
         </extension>
       </searchInclude>
       <!-- TBC 
@@ -127,7 +127,7 @@
       </searchParam>
       <searchParam>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-          <valueCode value="SHOULD"/>
+          <valueCode value="SHALL"/>
         </extension>
         <name value="supporting-info"/>
         <definition value="http://hl7.org.au/fhir/ereq/SearchParameter/au-erequesting-servicerequest-supporting-info"/>

--- a/input/resources/au-erequesting-server.xml
+++ b/input/resources/au-erequesting-server.xml
@@ -822,7 +822,7 @@
           <valueCode value="SHOULD"/>
         </extension>
       </supportedProfile>
-      <documentation value="The AU eRequesting Server actor **SHALL** support the ServiceRequest resource, at least one AU eRequesting Diagnostic Request profile, and the conformance expectations for the ServiceRequest resource.&#xa;&#xa;The AU eRequesting Server actor **SHALL** support the `_include` parameter for `ServiceRequest:patient` and `ServiceRequest:requester`, and **SHOULD** support the `_include` parameter for `ServiceRequest:encounter` and `ServiceRequest:supporting-info`."/>
+      <documentation value="The AU eRequesting Server actor **SHALL** support the ServiceRequest resource, at least one AU eRequesting Diagnostic Request profile, and the conformance expectations for the ServiceRequest resource.&#xa;&#xa;The AU eRequesting Server actor **SHALL** support the `_include` parameter for `ServiceRequest:patient`, `ServiceRequest:requester` and `ServiceRequest:supporting-info`, and **SHOULD** support the `_include` parameter for `ServiceRequest:encounter`."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHALL"/>
@@ -864,7 +864,7 @@
       </searchInclude>
       <searchInclude value="ServiceRequest:supporting-info">
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-        <valueCode value="SHOULD"/>
+        <valueCode value="SHALL"/>
         </extension>
       </searchInclude>
       <!-- TBC 
@@ -891,7 +891,7 @@
       </searchParam>
       <searchParam>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-          <valueCode value="SHOULD"/>
+          <valueCode value="SHALL"/>
         </extension>
         <name value="supporting-info"/>
         <definition value="http://hl7.org.au/fhir/ereq/SearchParameter/au-erequesting-servicerequest-supporting-info"/>


### PR DESCRIPTION
[FHIR-51253](https://jira.hl7.org/browse/FHIR-51253)
* change conformance for supporting-info and _include=ServiceRequest:supporting-info from SHOULD to SHALL in CapStat
* update above in ServiceRequest notes
* change log entry

[FHIR-51406](https://jira.hl7.org/browse/FHIR-51406)
* add support for update interaction for Filler to CapStat
* change log entry