### PR TITLE
AUeReqDI statement re AUCDI R1/2 + pregnancy status (FHIR-51565)

### DIFF
--- a/input/pagecontent/auereqdi.md
+++ b/input/pagecontent/auereqdi.md
@@ -58,221 +58,221 @@ Column attribute descriptions are as follows:
     <td rowspan="9">Service request</td>
     <td colspan="2">Service name</td>
     <td><a href="StructureDefinition-au-erequesting-diagnosticrequest.html">AU eRequesting Diagnostic Request</a></td>
-    <td>ServiceRequest.code</td>
+    <td><code>ServiceRequest.code</code></td>
     <td></td>
   </tr>
   <tr>
     <td colspan="2">Clinical indication</td>
     <td><a href="StructureDefinition-au-erequesting-diagnosticrequest.html">AU eRequesting Diagnostic Request</a></td>
-    <td>ServiceRequest.reasonCode</td>
+    <td><code>ServiceRequest.reasonCode</code></td>
     <td></td>
   </tr>
   <tr>
     <td colspan="2">Clinical context</td>
     <td><a href="StructureDefinition-au-erequesting-diagnosticrequest.html">AU eRequesting Diagnostic Request</a></td>
-    <td>ServiceRequest.supportingInfo:clinicalContext</td>
+    <td><code>ServiceRequest.supportingInfo:clinicalContext</code></td>
     <td></td>
   </tr>
   <tr>
     <td colspan="2">Urgency</td>
     <td><a href="StructureDefinition-au-erequesting-diagnosticrequest.html">AU eRequesting Diagnostic Request</a></td>
-    <td>ServiceRequest.priority</td>
+    <td><code>ServiceRequest.priority</code></td>
     <td></td>
   </tr>
    <tr>
     <td colspan="2">Service timing</td>
     <td><a href="StructureDefinition-au-erequesting-diagnosticrequest.html">AU eRequesting Diagnostic Request</a></td>
-    <td>ServiceRequest.occurrence[x]</td>
+    <td><code>ServiceRequest.occurrence[x]</code></td>
     <td>This element is choice between occurrenceTiming | occurrenceDateTime | occurrencePeriod.</td>
   </tr>
    <tr>
     <td colspan="2">Comment</td>
     <td><a href="StructureDefinition-au-erequesting-diagnosticrequest.html">AU eRequesting Diagnostic Request</a></td>
-    <td>ServiceRequest.note</td>
+    <td><code>ServiceRequest.note</code></td>
     <td></td>
   </tr>
    <tr>
     <td colspan="2">Distribution list</td>
     <td><a href="StructureDefinition-au-erequesting-communicationrequest-copyto.html">AU eRequesting CommunicationRequest CopyTo</a></td>
-    <td>CommunicationRequest.recipient</td>
+    <td><code>CommunicationRequest.recipient</code></td>
     <td></td>
   </tr>
    <tr>
     <td colspan="2">Urgent contact</td>
     <td><a href="StructureDefinition-au-erequesting-communicationrequest-urgentprovider.html">AU eRequesting CommunicationRequest Urgent Provider</a></td>
-    <td>CommunicationRequest.recipient</td>
+    <td><code>CommunicationRequest.recipient</code></td>
     <td></td>
   </tr>
    <tr>
     <td colspan="2">Billing guidance</td>
     <td><a href="StructureDefinition-au-erequesting-diagnosticrequest.html">AU eRequesting Diagnostic Request</a><br><br><a href="StructureDefinition-au-erequesting-coverage.html">AU eRequesting Coverage</a></td>
-    <td>ServiceRequest.insurance<br><br>Coverage</td>
-    <td>ServiceRequest.insurance references a Coverage resource.</td>
+    <td><code>ServiceRequest.insurance</code><br><br><code>Coverage</code></td>
+    <td><code>ServiceRequest.insurance</code> references a Coverage resource.</td>
   </tr>
   <tr>
     <td rowspan="12">Medical imaging request</td>
     <td colspan="2">Test name</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-imag.html">AU eRequesting Imaging Request</a></td>
-    <td>ServiceRequest.code</td>
+    <td><code>ServiceRequest.code</code></td>
     <td></td>
   </tr>
   <tr>
     <td colspan="2">Modality</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-imag.html">AU eRequesting Imaging Request</a></td>
-    <td>ServiceRequest.code</td>
+    <td><code>ServiceRequest.code</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Target body site</td>
    <td><a href="StructureDefinition-au-erequesting-servicerequest-imag.html">AU eRequesting Imaging Request</a></td>
-    <td>ServiceRequest.code | ServiceRequest.bodySite</td>
+    <td><code>ServiceRequest.code</code> | <code>ServiceRequest.bodySite</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Contrast use</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-imag.html">AU eRequesting Imaging Request</a></td>
-    <td>ServiceRequest.code</td>
+    <td><code>ServiceRequest.code</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Clinical indication</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-imag.html">AU eRequesting Imaging Request</a></td>
-    <td>ServiceRequest.reasonCode</td>
+    <td><code>ServiceRequest.reasonCode</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Clinical context</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-imag.html">AU eRequesting Imaging Request</a></td>
-    <td>ServiceRequest.supportingInfo:clinicalContext</td>
+    <td><code>ServiceRequest.supportingInfo:clinicalContext</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Urgency</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-imag.html">AU eRequesting Imaging Request</a></td>
-    <td>ServiceRequest.priority</td>
+    <td><code>ServiceRequest.priority</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Service timing</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-imag.html">AU eRequesting Imaging Request</a></td>
-    <td>ServiceRequest.occurrence[x]</td>
+    <td><code>ServiceRequest.occurrence[x]</code></td>
     <td>This element is choice between occurrenceTiming | occurrenceDateTime | occurrencePeriod.</td>
   </tr>
     <tr>
     <td colspan="2">Comment</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-imag.html">AU eRequesting Imaging Request</a></td>
-    <td>ServiceRequest.note</td>
+    <td><code>ServiceRequest.note</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Distribution list</td>
     <td><a href="StructureDefinition-au-erequesting-communicationrequest-copyto.html">AU eRequesting CommunicationRequest CopyTo</a></td>
-    <td>CommunicationRequest.recipient</td>
+    <td><code>CommunicationRequest.recipient</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Urgent contact</td>
     <td><a href="StructureDefinition-au-erequesting-communicationrequest-urgentprovider.html">AU eRequesting CommunicationRequest Urgent Provider</a></td>
-    <td>CommunicationRequest.recipient</td>
+    <td><code>CommunicationRequest.recipient</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Billing guidance</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-imag.html">AU eRequesting Imaging Request</a><br><br><a href="StructureDefinition-au-erequesting-coverage.html">AU eRequesting Coverage</a></td>
-    <td>ServiceRequest.insurance<br><br>Coverage</td>
-    <td>ServiceRequest.insurance references a Coverage resource.</td>
+    <td><code>ServiceRequest.insurance</code><br><br><code>Coverage</code></td>
+    <td><code>ServiceRequest.insurance</code> references a Coverage resource.</td>
   </tr>
  <tr>
     <td rowspan="10">Pathology test request</td>
     <td colspan="2">Test name</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-path.html">AU eRequesting Pathology Request</a></td>
-    <td>ServiceRequest.code</td>
+    <td><code>ServiceRequest.code</code></td>
     <td></td>
   </tr>
   <tr>
     <td colspan="2">Fasting status</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-path.html">AU eRequesting Pathology Request</a></td>
-    <td>ServiceRequest.extension:fastingPrecondition</td>
+    <td><code>ServiceRequest.extension:fastingPrecondition</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Clinical indication</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-path.html">AU eRequesting Pathology Request</a></td>
-    <td>ServiceRequest.reasonCode</td>
+    <td><code>ServiceRequest.reasonCode</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Clinical context</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-path.html">AU eRequesting Pathology Request</a></td>
-    <td>ServiceRequest.supportingInfo.clinicalContext</td>
+    <td><code>ServiceRequest.supportingInfo.clinicalContext</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Urgency</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-path.html">AU eRequesting Pathology Request</a></td>
-    <td>ServiceRequest.priority</td>
+    <td><code>ServiceRequest.priority</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Service timing</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-path.html">AU eRequesting Pathology Request</a></td>
-    <td>ServiceRequest.occurrence[x]</td>
+    <td><code>ServiceRequest.occurrence[x]</code></td>
     <td>This element is choice between occurrenceTiming | occurrenceDateTime | occurrencePeriod.</td>
   </tr>
     <tr>
     <td colspan="2">Comment</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-path.html">AU eRequesting Pathology Request</a></td>
-    <td>ServiceRequest.note</td>
+    <td><code>ServiceRequest.note</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Distribution list</td>
     <td><a href="StructureDefinition-au-erequesting-communicationrequest-copyto.html">AU eRequesting CommunicationRequest CopyTo</a></td>
-    <td>CommunicationRequest.recipient</td>
+    <td><code>CommunicationRequest.recipient</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Urgent contact</td>
     <td><a href="StructureDefinition-au-erequesting-communicationrequest-urgentprovider.html">AU eRequesting CommunicationRequest Urgent Provider</a></td>
-    <td>CommunicationRequest.recipient</td>
+    <td><code>CommunicationRequest.recipient</code></td>
     <td></td>
   </tr>
     <tr>
     <td colspan="2">Billing guidance</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-path.html">AU eRequesting Pathology Request</a><br><br><a href="StructureDefinition-au-erequesting-coverage.html">AU eRequesting Coverage</a></td>
-    <td>ServiceRequest.insurance<br><br>Coverage</td>
-    <td>ServiceRequest.insurance references a Coverage resource.</td>
+    <td><code>ServiceRequest.insurance</code><br><br><code>Coverage</code></td>
+    <td><code>ServiceRequest.insurance</code> references a Coverage resource.</td>
   </tr>
   <tr>
     <td rowspan="4">Implanted medical device summary</td>
     <td colspan="2">Device type name</td>
     <td>Device</td>
-    <td>Device.type</td>
+    <td><code>Device.type</code></td>
     <td>The Device resource has not yet been profiled for use in AU eRequesting.</td>
   </tr>
   <tr>
     <td colspan="2">Current status</td>
     <td>Device</td>
-    <td>Device.status</td>
+    <td><code>Device.status</code></td>
     <td>The Device resource has not yet been profiled for use in AU eRequesting.</td>
   </tr>
     <tr>
     <td colspan="2">Overall comment</td>
     <td>Device</td>
-    <td>Device.note</td>
+    <td><code>Device.note</code></td>
     <td>The Device resource has not yet been profiled for use in AU eRequesting.</td>
   </tr>
     <tr>
     <td colspan="2">Last updated</td>
-    <td>TBD</td>
-    <td>TBD</td>
-    <td>Work is underway in AU eRequesting to map this element. Feedback is requested on the appropriateness of using Provenance or an extension to support last updated. Please comment by raising <a href="https://jira.hl7.org/projects/FHIR/issues">HL7 Jira Issues</a>.</td>
+    <td>-</td>
+    <td>-</td>
+    <td>The Device resource has not yet been profiled for use in AU eRequesting.</td>
   </tr>
   <tr>
     <td>Pregnancy summary (AUCDI R3+ backlog)</td>
     <td colspan="2">TBD</td>
     <td><a href="StructureDefinition-au-erequesting-diagnosticrequest.html">AU eRequesting Diagnostic Request</a></td>
-    <td>ServiceRequest.supportingInfo:pregnancyStatus</td>
+    <td><code>ServiceRequest.supportingInfo:pregnancyStatus</code></td>
     <td>Proposed to correspond to a future AUCDI pregnancy summary concept (in the AUCDI R3+ backlog), which is expected to describe pregnancy status within a single pregnancy and potentially include more granular states to encompass a continuum of pregnancy states. In AU eRequesting R1, the pregnancy status is constrained to Pregnant only, as advised by AUCDI authors, to ensure future compatibility.</td>
   </tr>
 </tbody>
@@ -290,19 +290,19 @@ Column attribute descriptions are as follows:
     <td rowspan="4">Adverse reaction risk summary</td>
     <td colspan="2">Substance name</td>
     <td><a href="https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-allergyintolerance.html">AU Core AllergyIntolerance</a></td>
-    <td>AllergyIntolerance.code</td>
+    <td><code>AllergyIntolerance.code</code></td>
     <td></td>
   </tr>
   <tr>
     <td colspan="2">Manifestation</td>
     <td><a href="https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-allergyintolerance.html">AU Core AllergyIntolerance</a></td>
-    <td>AllergyInterolance.reaction</td>
+    <td><code>AllergyInterolance.reaction</code></td>
     <td></td>
   </tr>
   <tr>
     <td colspan="2">Comment</td>
     <td><a href="https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-allergyintolerance.html">AU Core AllergyIntolerance</a></td>
-    <td>AllergyIntolerance.note</td>
+    <td><code>AllergyIntolerance.note</code></td>
     <td></td>
   </tr>
   <tr>
@@ -315,25 +315,25 @@ Column attribute descriptions are as follows:
     <td rowspan="5">Problem/Diagnosis summary</td>
     <td colspan="2">Problem / Diagnosis name</td>
     <td><a href="https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-condition.html">AU Core Condition</a></td>
-    <td>Condition.code</td>
+    <td><code>Condition.code</code></td>
     <td></td>
   </tr>
   <tr>
     <td colspan="2">Body site/laterality</td>
     <td><a href="https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-condition.html">AU Core Condition</a></td>
-    <td>Condition.code</td>
+    <td><code>Condition.code</code></td>
     <td></td>
   </tr>
   <tr>
     <td colspan="2">Status</td>
     <td><a href="https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-condition.html">AU Core Condition</a></td>
-    <td>Condition.clinicalStatus</td>
+    <td><code>Condition.clinicalStatus</code></td>
     <td></td>
   </tr>
   <tr>
     <td colspan="2">Comment</td>
     <td><a href="https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-condition.html">AU Core Condition</a></td>
-    <td>Condition.note</td>
+    <td><code>Condition.note</code></td>
     <td></td>
   </tr>
   <tr>
@@ -346,19 +346,19 @@ Column attribute descriptions are as follows:
     <td rowspan="4">Sex and gender summary</td>
     <td colspan="2">Sex assigned at birth</td>
     <td><a href="https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-patient.html">AU Core Patient</a></td>
-    <td>Patient.extension.where(url='http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender')</td>
+    <td><code>Patient.extension.where(url='http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender')</code></td>
     <td>The <a href="http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender">Person Recorded Sex or Gender extension</a> is profiled by <a href="https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-rsg-sexassignedab.html">AU Core Sex Assigned At Birth (RSG)</a> to represent the concept of Sex assigned at birth.</td>
   </tr>
   <tr>
     <td colspan="2">Gender identity</td>
     <td><a href="https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-patient.html">AU Core Patient</a></td>
-    <td>Patient.extension.where(url='http://hl7.org/fhir/StructureDefinition/individual-genderIdentity')</td>
+    <td><code>Patient.extension.where(url='http://hl7.org/fhir/StructureDefinition/individual-genderIdentity')</code></td>
     <td></td>
   </tr>
   <tr>
     <td colspan="2">Pronoun/s</td>
     <td><a href="https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-patient.html">AU Core Patient</a></td>
-    <td>Patient.extension.where(url='http://hl7.org/fhir/StructureDefinition/individual-pronouns')</td>
+    <td><code>Patient.extension.where(url='http://hl7.org/fhir/StructureDefinition/individual-pronouns')</code></td>
     <td></td>
   </tr>
   <tr>

--- a/input/pagecontent/auereqdi.md
+++ b/input/pagecontent/auereqdi.md
@@ -1,12 +1,15 @@
-[Australian eRequesting Data for Interoperability (AUeReqDI)](https://sparked.csiro.au/index.php/sparked-products-resources/auereqdi/auereqdi-release-1/) is the product of a national clinician focussed requirements gathering project operating as part of the [Sparked AU FHIR Accelerator](https://sparked.csiro.au/).  AUeReqDI outputs form a set of data requirements to be considered and referred to as part of the development and definition of AU eRequesting. 
+[Australian eRequesting Data for Interoperability (AUeReqDI)](https://sparked.csiro.au/index.php/products-resources/auereqdi/) is the product of a national clinician focussed requirements gathering project operating as part of the [Sparked AU FHIR Accelerator](https://sparked.csiro.au/).  AUeReqDI outputs form a set of data requirements to be considered and referred to as part of the development and definition of AU eRequesting. 
 
-The primary intent of AUeReqDI is to design and govern a collection of coherent, reusable building blocks known as ‘data groups’. These data groups specify “what” the clinical requirements of the clinical information that should be included for eRequests. However, it does not specify “how” the data is exchanged; this is the role fulfilled by the FHIR standard. AUeReqDI is not required to be implemented as a whole single product.  AUeReqDI builds upon and complements the foundational [Australian Core Data for Interoperability (AUCDI)](https://sparked.csiro.au/index.php/sparked-products-resources/australian-core-data-for-interoperability/aucdi-release-1/) and focuses on the specific use case of eRequesting.
+The primary intent of AUeReqDI is to design and govern a collection of coherent, reusable building blocks known as ‘data groups’. These data groups specify “what” the clinical requirements of the clinical information that should be included for eRequests. However, it does not specify “how” the data is exchanged; this is the role fulfilled by the FHIR standard. AUeReqDI is not required to be implemented as a whole single product.  AUeReqDI builds upon and complements the foundational [Australian Clinical Data for Interoperability (AUCDI)](https://sparked.csiro.au/index.php/products-resources/aucdi/) and focuses on the specific use case of eRequesting.
 
 AUeReqDI Release 1 (R1) is focused on an agreement of the minimum data required to support standardised eRequesting within the Australian health context, and forms a common language foundation that allows systems to exchange semantically accurate data for eRequests. It incorporates and builds upon prior work from national and international programs and initiatives, including the Royal College of Pathologists of Australasia (RCPA)'s Pathology information, Terminology and Units Standardisation (PITUS) framework and the Royal Australian New Zealand College of Radiology (RANZCR's) Radiology Referral Set.
 
-With AUeReqDI defining clinical data requirements and FHIR AU eRequesting providing the Implementation Guide for FHIR-based electronic requesting of diagnostic imaging and pathology services, an interpretation of AUeReqDI is necessary which is undertaken through the community.
+AU eRequesting is intended to provide an implementable standard for FHIR based interfaces for diagnostic requesting in Australia, providing:
+- an exchange standard for AUeReqDI (the underpinning clinical data model)
+- data model and RESTful API interactions that set minimum expectations for a system to create, update, search, and retrieve electronic diagnostic requests
+- a foundation focused on pathology and medical imaging requests in community-based care provision, with consideration for future eRequesting use cases beyond this scope 
 
-Updates to AU eRequesting and AU Core depend upon community input and we encourage our audience to submit questions and feedback on implementation guides by clicking on the Propose a change link in the footer of every page.  We encourage requesting any necessary clarifications to AUeReqDI or AUCDI through through the respective process that helps inform future updates to FHIR AU eRequesting and AU Core. 
+With AUeReqDI defining clinical data requirements and FHIR AU eRequesting providing the Implementation Guide for FHIR-based electronic requesting of diagnostic imaging and pathology services, an interpretation of AUeReqDI is necessary which is undertaken through the community.
 
 ### AU eRequesting, AUeReqDI and AUCDI versions
 
@@ -17,7 +20,7 @@ AUeReqDI R1 is aligned with AUCDI R1.
 AUCDI R2 was published after AUeReqDI R1, introducing additional and expanded data groups to support different use cases. These are not reflected in AUeReqDI R1.
 
 The following table shows the version alignment between AU eRequesting, AUeReqDI and AUCDI:
-<table border="1" cellspacing="0" cellpadding="0" width="100%">
+<table border="1" cellspacing="0" cellpadding="0" width="50%">
   <tr style="background-color: #f2f2f2;">
     <th>AU eRequesting Version</th>
     <th>AUeReqDI Version</th>
@@ -77,7 +80,7 @@ Column attribute descriptions are as follows:
     <td></td>
   </tr>
    <tr>
-    <td colspan="2">Service due</td>
+    <td colspan="2">Service timing</td>
     <td><a href="StructureDefinition-au-erequesting-diagnosticrequest.html">AU eRequesting Diagnostic Request</a></td>
     <td>ServiceRequest.occurrence[x]</td>
     <td>This element is choice between occurrenceTiming | occurrenceDateTime | occurrencePeriod.</td>
@@ -150,7 +153,7 @@ Column attribute descriptions are as follows:
     <td></td>
   </tr>
     <tr>
-    <td colspan="2">Service due</td>
+    <td colspan="2">Service timing</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-imag.html">AU eRequesting Imaging Request</a></td>
     <td>ServiceRequest.occurrence[x]</td>
     <td>This element is choice between occurrenceTiming | occurrenceDateTime | occurrencePeriod.</td>
@@ -211,7 +214,7 @@ Column attribute descriptions are as follows:
     <td></td>
   </tr>
     <tr>
-    <td colspan="2">Service due</td>
+    <td colspan="2">Service timing</td>
     <td><a href="StructureDefinition-au-erequesting-servicerequest-path.html">AU eRequesting Pathology Request</a></td>
     <td>ServiceRequest.occurrence[x]</td>
     <td>This element is choice between occurrenceTiming | occurrenceDateTime | occurrencePeriod.</td>
@@ -248,7 +251,7 @@ Column attribute descriptions are as follows:
     <td>The Device resource has not yet been profiled for use in AU eRequesting.</td>
   </tr>
   <tr>
-    <td colspan="2">Overall status</td>
+    <td colspan="2">Current status</td>
     <td>Device</td>
     <td>Device.status</td>
     <td>The Device resource has not yet been profiled for use in AU eRequesting.</td>

--- a/input/pagecontent/auereqdi.md
+++ b/input/pagecontent/auereqdi.md
@@ -8,6 +8,27 @@ With AUeReqDI defining clinical data requirements and FHIR AU eRequesting provid
 
 Updates to AU eRequesting and AU Core depend upon community input and we encourage our audience to submit questions and feedback on implementation guides by clicking on the Propose a change link in the footer of every page.  We encourage requesting any necessary clarifications to AUeReqDI or AUCDI through through the respective process that helps inform future updates to FHIR AU eRequesting and AU Core. 
 
+### AU eRequesting, AUeReqDI and AUCDI versions
+
+AU eRequesting, AUeReqDI and AUCDI are updated periodically. AUeReqDI R1 contains data groups required to facilitate the exchange of a pathology test and medical imaging request, and reuses data groups from AUCDI where relevant.
+
+AUeReqDI R1 is aligned with AUCDI R1.
+
+AUCDI R2 was published after AUeReqDI R1, introducing additional and expanded data groups to support different use cases. These are not reflected in AUeReqDI R1.
+
+The following table shows the version alignment between AU eRequesting, AUeReqDI and AUCDI:
+<table border="1" cellspacing="0" cellpadding="0" width="100%">
+  <tr style="background-color: #f2f2f2;">
+    <th>AU eRequesting Version</th>
+    <th>AUeReqDI Version</th>
+    <th>AUCDI Version</th>
+  </tr>
+  <tr>
+    <td>1.0.0</td>
+    <td>R1</td>
+    <td>R1</td>
+  </tr>
+</table>
 
 ### AUeReqDI mappings into AU eRequesting
 
@@ -220,7 +241,7 @@ Column attribute descriptions are as follows:
     <td>ServiceRequest.insurance references a Coverage resource.</td>
   </tr>
   <tr>
-    <td rowspan="10">Implanted medical device summary</td>
+    <td rowspan="4">Implanted medical device summary</td>
     <td colspan="2">Device type name</td>
     <td>Device</td>
     <td>Device.type</td>
@@ -243,6 +264,13 @@ Column attribute descriptions are as follows:
     <td>TBD</td>
     <td>TBD</td>
     <td>Work is underway in AU eRequesting to map this element. Feedback is requested on the appropriateness of using Provenance or an extension to support last updated. Please comment by raising <a href="https://jira.hl7.org/projects/FHIR/issues">HL7 Jira Issues</a>.</td>
+  </tr>
+  <tr>
+    <td>Pregnancy summary (AUCDI R3+ backlog)</td>
+    <td colspan="2">TBD</td>
+    <td><a href="StructureDefinition-au-erequesting-diagnosticrequest.html">AU eRequesting Diagnostic Request</a></td>
+    <td>ServiceRequest.supportingInfo:pregnancyStatus</td>
+    <td>Proposed to correspond to a future AUCDI pregnancy summary concept (in the AUCDI R3+ backlog), which is expected to describe pregnancy status within a single pregnancy and potentially include more granular states to encompass a continuum of pregnancy states. In AU eRequesting R1, the pregnancy status is constrained to Pregnant only, as advised by AUCDI authors, to ensure future compatibility.</td>
   </tr>
 </tbody>
 <thead>

--- a/input/pagecontent/auereqdi.md
+++ b/input/pagecontent/auereqdi.md
@@ -11,7 +11,7 @@ AU eRequesting is intended to provide an implementable standard for FHIR based i
 
 With AUeReqDI defining clinical data requirements and FHIR AU eRequesting providing the Implementation Guide for FHIR-based electronic requesting of diagnostic imaging and pathology services, an interpretation of AUeReqDI is necessary which is undertaken through the community.
 
-### AU eRequesting, AUeReqDI and AUCDI versions
+### AU eRequesting, AUeReqDI and AUCDI Versions
 
 AU eRequesting, AUeReqDI and AUCDI are updated periodically. AUeReqDI R1 contains data groups required to facilitate the exchange of a pathology test and medical imaging request, and reuses data groups from AUCDI where relevant.
 
@@ -33,7 +33,7 @@ The following table shows the version alignment between AU eRequesting, AUeReqDI
   </tr>
 </table>
 
-### AUeReqDI mappings into AU eRequesting
+### AUeReqDI Mappings Into AU eRequesting
 
 The table below shows the relationship between AUeReqDI and AUCDI Data Groups and Elements and AU eRequesting and AU Core profiles.<br/>
 Column attribute descriptions are as follows:


### PR DESCRIPTION
Part fix for [FHIR-51565](https://jira.hl7.org/browse/FHIR-51565)
* Statement regarding AUCDI R1/2
* Add mapping for pregnancy status

Add QA fixes:
* https://github.com/orgs/hl7au/projects/10/views/1?pane=issue&itemId=73596309 to add eReqDI intention blurb
* Align eReqDI Data Element names with published names in R1 (Service due changed to Service timing; Overall status changed to Current status)
* Remove comment against Device last updated and noted not currently profiled in AU eReq
* Add coding format to fhir path.
* Apply decision to make all headings title case (applies to all AU IGs)