### PR TITLE
QA: remove AU Base deprecated AHPRA profession details extension from example

### DIFF
--- a/input/examples/practitioner-losch-sallie.xml
+++ b/input/examples/practitioner-losch-sallie.xml
@@ -42,13 +42,6 @@
     </address>
     <gender value="female"/>
     <qualification>
-        <extension url="http://hl7.org.au/fhir/StructureDefinition/ahpraprofession-details">
-            <extension url="ahpraProfession">
-                <valueCodeableConcept>
-                    <text value="Other Medical Practitioners"/>
-                </valueCodeableConcept>
-            </extension>
-        </extension>
         <identifier>
             <type>
                 <coding>
@@ -64,9 +57,10 @@
         <code>
             <coding>
                 <system value="http://terminology.hl7.org.au/CodeSystem/v2-0360"/>
-                <code value="AUAHPRAProfession"/>
-                <display value="AHPRA Profession"/>
+                <code value="AHPRA"/>
+                <display value="AHPRA Registration"/>
             </coding>
+            <text value="Ahpra Other Medical Practitioners"/>
         </code>
     </qualification>
 </Practitioner>

--- a/input/examples/practitioner-losch-sallie.xml
+++ b/input/examples/practitioner-losch-sallie.xml
@@ -58,7 +58,7 @@
             <coding>
                 <system value="http://terminology.hl7.org.au/CodeSystem/v2-0360"/>
                 <code value="AHPRA"/>
-                <display value="AHPRA Registration"/>
+                <display value="Ahpra Registration"/>
             </coding>
             <text value="Ahpra Other Medical Practitioners"/>
         </code>


### PR DESCRIPTION
QA Fix: to resolve info message in QA.html: The extension http://hl7.org.au/fhir/StructureDefinition/ahpraprofession-details|6.0.0-ci-build is deprecated with the note This profile is deprecated in AU Base as no continued use or intent for further maturity development has been indicated by the community. Representing a simple Aprha registration qualification is supported in AU Base Practitioner as "Practitioner.qualification" with the code AHPRA.

* removed extension
* represented same information as per guidance in info message and based on AU Base examples