### PR TITLE
TC: Fasting Precond description, remove coding in Workflow headers, remove Location.mode from eg

### DIFF
--- a/input/examples/location-barney-view-private-hospital.xml
+++ b/input/examples/location-barney-view-private-hospital.xml
@@ -10,7 +10,6 @@
         <valueMarkdown value="Shows an example of a location, Barney View Private Hospital, for the *AU Core Location* profile."/>
     </extension>
     <name value="Barney View Private Hospital"/>
-    <mode value="instance"/>
     <address>
         <line value="195 Maple Cct"/>
         <city value="Barney View"/>

--- a/input/fsh/au-erequesting-diagnosticrequest.fsh
+++ b/input/fsh/au-erequesting-diagnosticrequest.fsh
@@ -352,7 +352,7 @@ Extension: AUeRequestingFastingPrecondition
 Parent: Extension
 Id: au-erequesting-fastingprecondition
 Title: "AU eRequesting Fasting Precondition"
-Description: "This profile defines the minimum expectations for representing fasting precondition in the AU eRequesting context. The fasting precondition is a code that indicates the recommendation related to the fasting status of the patient as a precondition to the diagnostic procedure or test being requested."
+Description: "This extension applies to the ServiceRequest resource and is used to represent whether fasting is a recommended precondition for the diagnostic request. It conveys the requester's recommendation regarding fasting at the time of ordering, not the actual fasting status of the patient."
 * ^status = #active
 * ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 1
 * ^context.type = #element

--- a/input/pagecontent/workflow.md
+++ b/input/pagecontent/workflow.md
@@ -16,7 +16,7 @@ The [AU eRequesting Task Status](ValueSet-au-erequesting-task-status.html) value
 
 The Task state (status) transitions described here reflect the lifecycle of a Task within AU eRequesting workflows for community-based pathology and imaging. These state transitions are intended to guide implementers in supporting consistent and coordinated workflow behaviour. While implementation flexibility can exist to meet business needs and constraints, supporting the suggested states and transitions will help promote interoperability and alignment across systems.
 
-The business rules that define which actors or system roles can modify or trigger changes to `Task.status` are not currently considered within the scope of AU eRequesting Release 1. However, guidance on aligning `ServiceRequest.status` and `Task.status` is provided in [Relationship between `ServiceRequest.status` and `Task.status`](#relationship-between-servicerequeststatus-and-taskstatus).
+The business rules that define which actors or system roles can modify or trigger changes to `Task.status` are not currently considered within the scope of AU eRequesting Release 1. However, guidance on aligning `ServiceRequest.status` and `Task.status` is provided in [Relationship between ServiceRequest.status and Task.status](#relationship-between-servicerequeststatus-and-taskstatus).
 <br/>
 
 <figure style="background:white;">
@@ -33,7 +33,7 @@ The table below supplements Figure 1 by providing implementation guidance for AU
   <thead>
     <tr>
       <th colspan="4" style="text-align:center; padding:6px; font-weight:bold; font-size:1.1em;">
-        AU eRequesting Task State Represented by <code>Task.status</code> and Allowed Transitions
+        AU eRequesting Task State Represented by Task.status and Allowed Transitions
       </th>
     </tr>
     <tr>
@@ -148,7 +148,7 @@ The table below supplements Figure 1 by providing implementation guidance for AU
 <br/> 
 
 
-#### `Task.status` and Relationship with `Task.statusReason` and `Task.businessStatus`
+#### Task.status and Relationship with Task.statusReason and Task.businessStatus
 
 - Use `Task.status` to represent the current state of the Task. These states are encoded with values from the [AU eRequesting Task Status](ValueSet-au-erequesting-task-status.html) value set.
 - Use the optional `Task.statusReason` to explain why the Task transitioned to states such as "rejected", "cancelled", "on-hold", or "failed", providing context for deviations from the expected workflow.
@@ -164,9 +164,9 @@ The following table outlines the recommended mapping between [AU eRequesting Tas
   <thead>
     <tr>
       <th style="width:10%; padding:6px;">Context</th>
-      <th style="width:25%; padding:6px;">AU eRequesting Task Business Status codes for <code>Task.businessStatus</code></th>
+      <th style="width:25%; padding:6px;">AU eRequesting Task Business Status codes for Task.businessStatus</th>
       <th style="width:40%; padding:6px;">Description</th>
-      <th style="width:25%; padding:6px;">Relationship to AU eRequesting Task Status codes for <code>Task.status</code></th>
+      <th style="width:25%; padding:6px;">Relationship to AU eRequesting Task Status codes for Task.status</th>
     </tr>
   </thead>
   <tbody>
@@ -229,7 +229,7 @@ The following table outlines the recommended mapping between [AU eRequesting Tas
 <br/> 
 
 
-#### Relationship Between AU eRequesting Task Group `Task.status` and AU eRequesting Task Diagnostic Request `Task.status`
+#### Relationship Between AU eRequesting Task Group Task.status and AU eRequesting Task Diagnostic Request Task.status
 The [AU eRequesting Task Group](StructureDefinition-au-erequesting-task-group.html) is used to represent and coordinate the overall group of requests. It allows the AU eRequesting Filler actor to manage the group as a single coordinated request, supporting fulfilment, progress tracking and status updates across the group. See [Diagnostic Request Grouping](general-guidance.html#diagnostic-request-grouping) guidance for more information. 
 
 It is expected that the status of the task group will reflect the most appropriate status among the individual [AU eRequesting Task Diagnostic Request(s)](StructureDefinition-au-erequesting-task-diagnosticrequest.html), however this is not enforced. Changes to other resources, such as `ServiceRequest.status`, cannot be reliably acted on by the filler unless those changes are also reflected in the status of the task group.
@@ -250,7 +250,7 @@ The table below provides request state implementation guidance for AU eRequestin
   <thead>
     <tr>
       <th colspan="3" style="text-align:center; padding:6px; font-weight:bold; font-size:1.1em;">
-        AU eRequesting Request States Represented by <code>ServiceRequest.status</code>
+        AU eRequesting Request States Represented by ServiceRequest.status
       </th>
     </tr>
     <tr>
@@ -329,13 +329,13 @@ The table below provides request state implementation guidance for AU eRequestin
 <br/> 
 
 
-#### Relationship Between `ServiceRequest.status` and `ServiceRequest.extension:statusReason`
+#### Relationship Between ServiceRequest.status and ServiceRequest.extension:statusReason
 
 - Use `ServiceRequest.status` to represent the current state of the [AU eRequesting Diagnostic Request](StructureDefinition-au-erequesting-diagnosticrequest.html). These states are encoded using codes from the [AU eRequesting RequestStatus](ValueSet-au-erequesting-request-status.html) value set.
 - `ServiceRequest.extension:statusReason` provides optional explanatory context about why the request is in that particular state. It is not typically required for normal progression through the workflow (e.g. from "active" to "completed"), however it is intended to provide business-relevant context in exception scenarios, such as when a request is placed "on-hold", "revoked", or marked "entered-in-error".
   - There is no defined value set for `ServiceRequest.extension:statusReason`. When used, this element is expected to carry meaningful data including a human-readable description in `ServiceRequest.extension:statusReason.text`.
 
-#### Relationship Between `ServiceRequest.status` and `Task.status`
+#### Relationship Between ServiceRequest.status and Task.status
 
 - While the [AU eRequesting Diagnostic Request](StructureDefinition-au-erequesting-diagnosticrequest.html) and [AU eRequesting Task Diagnostic Request](StructureDefinition-au-erequesting-task-diagnosticrequest.html) are loosely coupled, in practice, changes in `ServiceRequest.status` are expected to be reflected in the corresponding `Task.status` to maintain alignment across resources involved in the workflow. Placers are responsible for managing this alignment, as changes in the diagnostic request status often require corresponding updates in fulfilment management. Failure to maintain this alignment can lead to workflow inconsistencies, such as orphaned tasks or misaligned expectations between placers and fillers.
 - Some typical business rules on these status relationships are outlined in the [Request States](#request-states) table above.


### PR DESCRIPTION
TC [FHIR-52346](https://jira.hl7.org/browse/FHIR-52346)
* removed Location.mode from Location example.

TC [FHIR-52291](https://jira.hl7.org/browse/FHIR-52291)
* removed code formatting from headings, subheadings and heading links in Workflow Guidance page.

TC [FHIR-52272](https://jira.hl7.org/browse/FHIR-52272)
* changed AU eRequesting Fasting Precondition extension description.