### PR TITLE
TC: fixed chained search examples; fix group-identifier search examples (FHIR-52290, FHIR-51917)

### DIFF
--- a/input/includes/task_group_notes.md
+++ b/input/includes/task_group_notes.md
@@ -33,17 +33,17 @@ The following search parameters and search parameter combinations are supported.
 
 1. Combined **[`_lastUpdated`](https://hl7.org/fhir/R4/resource.html#search)** and **[`status`](https://hl7.org/fhir/R4/task.html#search)** and **[`owner`](https://hl7.org/fhir/R4/task.html#search)** search parameters
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:owner`, `Task:patient`, and `Task:requester`
-   - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][code]`)
+   - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][value]`)
    - including support for **[`multipleOr`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)** search on `status`
    - including support for **[`multipleAnd`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)** search on `_lastUpdated`
    - including support for search comparators `gt`, `lt`, `ge`, `le` on `_lastUpdated`
 
-    `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner={Type/}[id]` or optionally `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner.identifier=[system|][code]`
+    `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner={Type/}[id]` or optionally `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner:Organization.identifier=[system|][value]`
 
     Example:
     
       1. GET [base]/Task?_lastUpdated=gt2010-10-01&status=completed&owner=https://elimbahmedicalcentre.example.com.au/orders/practitioner-identifier\|EMC1234567-1234
-      1. GET [base]/Task?_lastUpdated=gt2010-10-01&status=completed&owner.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455
+      1. GET [base]/Task?_lastUpdated=gt2010-10-01&status=completed&owner:Organization.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455
       1. GET [base]/Task?_lastUpdated=gt2010-10-01&status=accepted,in-progress&owner=https://elimbahmedicalcentre.example.com.au/orders/practitioner-identifier\|EMC1234567-1234&_include=Task:patient&_include=Task:requester&_include=Task:owner
 
     *Implementation Notes:* Fetches a bundle containing Task resources matching the _lastUpdated date, owner and status ([how to search by date](https://build.fhir.org/search.html#date), [how to search by token](http://hl7.org/fhir/R4/search.html#token), [how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
@@ -79,14 +79,14 @@ The following search parameters and search parameter combinations are supported.
 
 1. **[`owner`](https://hl7.org/fhir/R4/task.html#search)** search parameter
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:owner`, `Task:patient`, and `Task:requester`
-   - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][code]`)
+   - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][value]`)
 
-    `GET [base]/Task?owner={Type/}[id]` or optionally `GET [base]/Task?owner.identifier=[system|][code]`
+    `GET [base]/Task?owner={Type/}[id]` or optionally `GET [base]/Task?owner:Organization.identifier=[system|][value]`
 
     Example:
     
       1. GET [base]/Task?owner=5678
-      1. GET [base]/Task?owner.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455
+      1. GET [base]/Task?owner:Organization.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455
       1. GET [base]/Task?owner=5678&_include=Task:patient&_include=Task:requester&_include=Task:owner
 
     *Implementation Notes:* Fetches a bundle containing Task resources matching the owner ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
@@ -94,15 +94,15 @@ The following search parameters and search parameter combinations are supported.
 
 1. Combined **[`owner`](https://hl7.org/fhir/R4/task.html#search)** and **[`status`](https://hl7.org/fhir/R4/task.html#search)** search parameters:   
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:owner`, `Task:patient`, and `Task:requester`
-   - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][code]`)
+   - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][value]`)
    - including support for **[`multipleOr`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)** search on `status`
 
-    `GET [base]/Task?owner={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?owner.identifier=[system|][code]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Task?owner={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?owner:Organization.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
       1. GET [base]/Task?owner=5678&status=completed
-      1. GET [base]/Task?owner.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455&status=completed
+      1. GET [base]/Task?owner:Organization.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455&status=completed
       1. GET [base]/Task?owner=5678&status=completed&_include=Task:patient&_include=Task:requester&_include=Task:owner
       1. GET [base]/Task?owner=5678&status=accepted,in-progress
 
@@ -111,14 +111,14 @@ The following search parameters and search parameter combinations are supported.
 
 1. **[`patient`](https://hl7.org/fhir/R4/task.html#search)** search parameter
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:owner`, `Task:patient`, and `Task:requester`
-   - including support for chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
+   - including support for chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][value]`)
 
-    `GET [base]/Task?patient={Type/}[id]` or optionally `GET [base]/Task?patient.identifier=[system|][code]`
+    `GET [base]/Task?patient={Type/}[id]` or optionally `GET [base]/Task?patient:Patient.identifier=[system|][value]`
 
     Example:
     
       1. GET [base]/Task?patient=5678
-      1. GET [base]/Task?patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952
+      1. GET [base]/Task?patient:Patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952
       1. GET [base]/Task?patient=5678&_include=Task:patient&_include=Task:requester&_include=Task:owner
 
     *Implementation Notes:* Fetches a bundle containing Task resources matching the patient ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
@@ -126,15 +126,15 @@ The following search parameters and search parameter combinations are supported.
 
 1. Combined **[`patient`](https://hl7.org/fhir/R4/task.html#search)** and **[`status`](https://hl7.org/fhir/R4/task.html#search)** search parameters
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:owner`, `Task:patient`, and `Task:requester`
-   - including support for chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
+   - including support for chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][value]`)
    - including support for **[`multipleOr`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)** search on `status`
 
-   `GET [base]/Task?patient={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?patient.identifier=[system|][code]&status={system|}[code]{,{system|}[code],...}`
+   `GET [base]/Task?patient={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?patient:Patient.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
       1. GET [base]/Task?patient=5678&status=completed
-      1. GET [base]/Task?patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952&status=completed
+      1. GET [base]/Task?patient:Patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952&status=completed
       1. GET [base]/Task?patient=5678&status=completed&_include=Task:patient&_include=Task:requester&_include=Task:owner
       1. GET [base]/Task?patient=5678&status=accepted,in-progress
 
@@ -143,14 +143,14 @@ The following search parameters and search parameter combinations are supported.
 
 1. **[`requester`](https://hl7.org/fhir/R4/task.html#search)** search parameter
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:owner`, `Task:patient`, and `Task:requester`
-   - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][code]`)
+   - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][value]`)
 
-    `GET [base]/Task?requester={Type/}[id]` or optionally `GET [base]/Task?requester.identifier=[system|][code]`
+    `GET [base]/Task?requester={Type/}[id]` or optionally `GET [base]/Task?requester:PractitionerRole.identifier=[system|][value]`
 
     Example:
     
       1. GET [base]/Task?requester=5678
-      1. GET [base]/Task?requester.identifier=http://ns.electronichealth.net.au/id/medicare-provider-number\|553255
+      1. GET [base]/Task?requester:PractitionerRole.identifier=http://ns.electronichealth.net.au/id/medicare-provider-number\|553255
       1. GET [base]/Task?requester=5678&_include=Task:patient&_include=Task:requester&_include=Task:owner
 
     *Implementation Notes:* Fetches a bundle containing Task resources matching the requester ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
@@ -158,15 +158,15 @@ The following search parameters and search parameter combinations are supported.
 
 1. Combined **[`requester`](https://hl7.org/fhir/R4/task.html#search)** and **[`status`](https://hl7.org/fhir/R4/task.html#search)** search parameters
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:owner`, `Task:patient`, and `Task:requester`
-   - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][code]`)
+   - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][value]`)
    - including support for **[`multipleOr`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)** search on `status`
 
-    `GET [base]/Task?requester={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?requester.identifier=[system|][code]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Task?requester={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?requester:PractitionerRole.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
       1. GET [base]/Task?requester=5678&status=completed
-      1. GET [base]/Task?requester.identifier=http://ns.electronichealth.net.au/id/medicare-provider-number\|553255&status=completed
+      1. GET [base]/Task?requester:PractitionerRole.identifier=http://ns.electronichealth.net.au/id/medicare-provider-number\|553255&status=completed
       1. GET [base]/Task?requester=5678&status=accepted,in-progress&_include=Task:patient&_include=Task:requester&_include=Task:owner
 
     *Implementation Notes:* Fetches a bundle containing Task resources matching the requester and status ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference), [how to search by token](http://hl7.org/fhir/R4/search.html#token))

--- a/input/includes/task_group_notes.md
+++ b/input/includes/task_group_notes.md
@@ -113,12 +113,12 @@ The following search parameters and search parameter combinations are supported.
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:owner`, `Task:patient`, and `Task:requester`
    - including support for chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][value]`)
 
-    `GET [base]/Task?patient={Type/}[id]` or optionally `GET [base]/Task?patient:Patient.identifier=[system|][value]`
+    `GET [base]/Task?patient={Type/}[id]` or optionally `GET [base]/Task?patient.identifier=[system|][value]`
 
     Example:
     
       1. GET [base]/Task?patient=5678
-      1. GET [base]/Task?patient:Patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952
+      1. GET [base]/Task?patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952
       1. GET [base]/Task?patient=5678&_include=Task:patient&_include=Task:requester&_include=Task:owner
 
     *Implementation Notes:* Fetches a bundle containing Task resources matching the patient ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
@@ -129,12 +129,12 @@ The following search parameters and search parameter combinations are supported.
    - including support for chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][value]`)
    - including support for **[`multipleOr`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)** search on `status`
 
-   `GET [base]/Task?patient={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?patient:Patient.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
+   `GET [base]/Task?patient={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?patient.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
       1. GET [base]/Task?patient=5678&status=completed
-      1. GET [base]/Task?patient:Patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952&status=completed
+      1. GET [base]/Task?patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952&status=completed
       1. GET [base]/Task?patient=5678&status=completed&_include=Task:patient&_include=Task:requester&_include=Task:owner
       1. GET [base]/Task?patient=5678&status=accepted,in-progress
 

--- a/input/includes/task_group_notes.md
+++ b/input/includes/task_group_notes.md
@@ -67,12 +67,12 @@ The following search parameters and search parameter combinations are supported.
 1. **[`group-identifier`](https://hl7.org/fhir/R4/task.html#search)** search parameter
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:owner`, `Task:patient`, and `Task:requester`
 
-    `GET [base]/Task?groupIdentifier={system|}{value}`
+    `GET [base]/Task?group-identifier={system|}{value}`
 
     Example:
     
-      1. GET [base]/Task?groupIdentifier=https://elimbahmedicalcentre.example.com.au/orders/task-identifier\|EMC1234567-1234 
-      1. GET [base]/Task?groupIdentifier=https://elimbahmedicalcentre.example.com.au/orders/task-identifier\|EMC1234567-1234&_include=Task:patient&_include=Task:requester&_include=Task:owner
+      1. GET [base]/Task?group-identifier=https://elimbahmedicalcentre.example.com.au/orders/task-identifier\|EMC1234567-1234 
+      1. GET [base]/Task?group-identifier=https://elimbahmedicalcentre.example.com.au/orders/task-identifier\|EMC1234567-1234&_include=Task:patient&_include=Task:requester&_include=Task:owner
 
     *Implementation Notes:* Fetches a bundle containing Task resources matching the group identifier ([how to search by token](http://hl7.org/fhir/R4/search.html#token))
 

--- a/input/includes/task_group_notes.md
+++ b/input/includes/task_group_notes.md
@@ -38,7 +38,7 @@ The following search parameters and search parameter combinations are supported.
    - including support for **[`multipleAnd`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)** search on `_lastUpdated`
    - including support for search comparators `gt`, `lt`, `ge`, `le` on `_lastUpdated`
 
-    `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner={Type/}[id]` or optionally `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner:Organization.identifier=[system|][value]`
+    `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner={Type/}[id]` or optionally `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner.identifier=[system|][value]`
 
     Example:
     
@@ -81,7 +81,7 @@ The following search parameters and search parameter combinations are supported.
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:owner`, `Task:patient`, and `Task:requester`
    - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][value]`)
 
-    `GET [base]/Task?owner={Type/}[id]` or optionally `GET [base]/Task?owner:Organization.identifier=[system|][value]`
+    `GET [base]/Task?owner={Type/}[id]` or optionally `GET [base]/Task?owner.identifier=[system|][value]`
 
     Example:
     
@@ -97,7 +97,7 @@ The following search parameters and search parameter combinations are supported.
    - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][value]`)
    - including support for **[`multipleOr`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)** search on `status`
 
-    `GET [base]/Task?owner={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?owner:Organization.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Task?owner={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?owner.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -145,7 +145,7 @@ The following search parameters and search parameter combinations are supported.
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:owner`, `Task:patient`, and `Task:requester`
    - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][value]`)
 
-    `GET [base]/Task?requester={Type/}[id]` or optionally `GET [base]/Task?requester:PractitionerRole.identifier=[system|][value]`
+    `GET [base]/Task?requester={Type/}[id]` or optionally `GET [base]/Task?requester.identifier=[system|][value]`
 
     Example:
     
@@ -161,7 +161,7 @@ The following search parameters and search parameter combinations are supported.
    - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][value]`)
    - including support for **[`multipleOr`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)** search on `status`
 
-    `GET [base]/Task?requester={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?requester:PractitionerRole.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Task?requester={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?requester.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     

--- a/input/includes/task_notes.md
+++ b/input/includes/task_notes.md
@@ -80,12 +80,12 @@ The following search parameters and search parameter combinations are supported.
 1. **[`group-identifier`](https://hl7.org/fhir/R4/task.html#search)** search parameter
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
 
-    `GET [base]/Task?groupIdentifier={system|}{value}`
+    `GET [base]/Task?group-identifier={system|}{value}`
 
     Example:
     
-      1. GET [base]/Task?groupIdentifier=https://elimbahmedicalcentre.example.com.au/orders/task-identifier\|EMC1234567-1234 
-      1. GET [base]/Task?groupIdentifier=https://elimbahmedicalcentre.example.com.au/orders/task-identifier\|EMC1234567-1234&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
+      1. GET [base]/Task?group-identifier=https://elimbahmedicalcentre.example.com.au/orders/task-identifier\|EMC1234567-1234 
+      1. GET [base]/Task?group-identifier=https://elimbahmedicalcentre.example.com.au/orders/task-identifier\|EMC1234567-1234&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
 
     *Implementation Notes:* Fetches a bundle containing Task resources matching the group identifier ([how to search by token](http://hl7.org/fhir/R4/search.html#token))
 

--- a/input/includes/task_notes.md
+++ b/input/includes/task_notes.md
@@ -126,12 +126,12 @@ The following search parameters and search parameter combinations are supported.
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
    - including support for chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][value]`)
 
-    `GET [base]/Task?patient={Type/}[id]` or optionally `GET [base]/Task?patient:Patient.identifier=[system|][value]`
+    `GET [base]/Task?patient={Type/}[id]` or optionally `GET [base]/Task?patient.identifier=[system|][value]`
 
     Example:
     
       1. GET [base]/Task?patient=5678
-      1. GET [base]/Task?patient:Patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952
+      1. GET [base]/Task?patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952
       1. GET [base]/Task?patient=5678&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
 
     *Implementation Notes:* Fetches a bundle containing Task resources matching the patient ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
@@ -143,12 +143,12 @@ The following search parameters and search parameter combinations are supported.
    - including support for **[`multipleOr`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)** search on `status`
 
 
-   `GET [base]/Task?patient={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?patient:Patient.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
+   `GET [base]/Task?patient={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?patient.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
       1. GET [base]/Task?patient=5678&status=completed
-      1. GET [base]/Task?patient:Patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952&status=completed
+      1. GET [base]/Task?patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952&status=completed
       1. GET [base]/Task?patient=5678&status=completed&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
       1. GET [base]/Task?patient=5678&&status=accepted,in-progress
 

--- a/input/includes/task_notes.md
+++ b/input/includes/task_notes.md
@@ -33,17 +33,17 @@ The following search parameters and search parameter combinations are supported.
 
 1. Combined **[`_lastUpdated`](https://hl7.org/fhir/R4/resource.html#search)** and **[`status`](https://hl7.org/fhir/R4/task.html#search)** and **[`owner`](https://hl7.org/fhir/R4/task.html#search)** search parameters
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
-   - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][code]`)
+   - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][value]`)
    - including support for **[`multipleOr`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)** search on `status`
    - including support for **[`multipleAnd`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)** search on `_lastUpdated`
    - including support for search comparators `gt`, `lt`, `ge`, `le` on `_lastUpdated`
 
-    `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner={Type/}[id]` or optionally `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner.identifier=[system|][code]`
+    `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner={Type/}[id]` or optionally `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner:Organization.identifier=[system|][value]`
 
     Example:
     
       1. GET [base]/Task?_lastUpdated=gt2010-10-01&status=completed&owner=https://elimbahmedicalcentre.example.com.au/orders/practitioner-identifier\|EMC1234567-1234
-      1. GET [base]/Task?_lastUpdated=gt2010-10-01&status=completed&owner.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455
+      1. GET [base]/Task?_lastUpdated=gt2010-10-01&status=completed&owner:Organization.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455
       1. GET [base]/Task?_lastUpdated=gt2010-10-01&status=accepted,in-progress&owner=https://elimbahmedicalcentre.example.com.au/orders/practitioner-identifier\|EMC1234567-1234&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
 
     *Implementation Notes:* Fetches a bundle containing Task resources matching the _lastUpdated date, owner and status ([how to search by date](https://build.fhir.org/search.html#date), [how to search by token](http://hl7.org/fhir/R4/search.html#token), [how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
@@ -92,14 +92,14 @@ The following search parameters and search parameter combinations are supported.
 
 1. **[`owner`](https://hl7.org/fhir/R4/task.html#search)** search parameter
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
-   - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][code]`)
+   - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][value]`)
 
-    `GET [base]/Task?owner={Type/}[id]` or optionally `GET [base]/Task?owner.identifier=[system|][code]`
+    `GET [base]/Task?owner={Type/}[id]` or optionally `GET [base]/Task?owner:Organization.identifier=[system|][value]`
 
     Example:
     
       1. GET [base]/Task?owner=5678
-      1. GET [base]/Task?owner.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455
+      1. GET [base]/Task?owner:Organization.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455
       1. GET [base]/Task?owner=5678&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
 
     *Implementation Notes:* Fetches a bundle containing Task resources matching the owner ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
@@ -107,15 +107,15 @@ The following search parameters and search parameter combinations are supported.
 
 1. Combined **[`owner`](https://hl7.org/fhir/R4/task.html#search)** and **[`status`](https://hl7.org/fhir/R4/task.html#search)** search parameters:   
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
-   - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][code]`)
+   - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][value]`)
    - including support for **[`multipleOr`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)** search on `status`
 
-    `GET [base]/Task?owner={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?owner.identifier=[system|][code]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Task?owner={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?owner:Organization.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
       1. GET [base]/Task?owner=5678&status=completed
-      1. GET [base]/Task?owner.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455&status=completed
+      1. GET [base]/Task?owner:Organization.identifier=http://ns.electronichealth.net.au/id/hi/hpio/1.0\|8003621566684455&status=completed
       1. GET [base]/Task?owner=5678&status=completed&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
       1. GET [base]/Task?owner=5678&status=accepted,in-progress
 
@@ -124,14 +124,14 @@ The following search parameters and search parameter combinations are supported.
 
 1. **[`patient`](https://hl7.org/fhir/R4/task.html#search)** search parameter
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
-   - including support for chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
+   - including support for chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][value]`)
 
-    `GET [base]/Task?patient={Type/}[id]` or optionally `GET [base]/Task?patient.identifier=[system|][code]`
+    `GET [base]/Task?patient={Type/}[id]` or optionally `GET [base]/Task?patient:Patient.identifier=[system|][value]`
 
     Example:
     
       1. GET [base]/Task?patient=5678
-      1. GET [base]/Task?patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952
+      1. GET [base]/Task?patient:Patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952
       1. GET [base]/Task?patient=5678&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
 
     *Implementation Notes:* Fetches a bundle containing Task resources matching the patient ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
@@ -139,16 +139,16 @@ The following search parameters and search parameter combinations are supported.
 
 1. Combined **[`patient`](https://hl7.org/fhir/R4/task.html#search)** and **[`status`](https://hl7.org/fhir/R4/task.html#search)** search parameters
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
-   - including support for chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
+   - including support for chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][value]`)
    - including support for **[`multipleOr`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)** search on `status`
 
 
-   `GET [base]/Task?patient={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?patient.identifier=[system|][code]&status={system|}[code]{,{system|}[code],...}`
+   `GET [base]/Task?patient={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?patient:Patient.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
       1. GET [base]/Task?patient=5678&status=completed
-      1. GET [base]/Task?patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952&status=completed
+      1. GET [base]/Task?patient:Patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952&status=completed
       1. GET [base]/Task?patient=5678&status=completed&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
       1. GET [base]/Task?patient=5678&&status=accepted,in-progress
 
@@ -157,14 +157,14 @@ The following search parameters and search parameter combinations are supported.
 
 1. **[`requester`](https://hl7.org/fhir/R4/task.html#search)** search parameter
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
-   - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][code]`)
+   - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][value]`)
 
-    `GET [base]/Task?requester={Type/}[id]` or optionally `GET [base]/Task?requester.identifier=[system|][code]`
+    `GET [base]/Task?requester={Type/}[id]` or optionally `GET [base]/Task?requester:PractitionerRole.identifier=[system|][value]`
 
     Example:
     
       1. GET [base]/Task?requester=5678
-      1. GET [base]/Task?requester.identifier=http://ns.electronichealth.net.au/id/medicare-provider-number\|553255
+      1. GET [base]/Task?requester:PractitionerRole.identifier=http://ns.electronichealth.net.au/id/medicare-provider-number\|553255
       1. GET [base]/Task?requester=5678&_include=Task:patient&_include=Task:requester&_include=Task:owner&_include=Task:focus
 
     *Implementation Notes:* Fetches a bundle containing Task resources matching the requester ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference))
@@ -172,15 +172,15 @@ The following search parameters and search parameter combinations are supported.
 
 1. Combined **[`requester`](https://hl7.org/fhir/R4/task.html#search)** and **[`status`](https://hl7.org/fhir/R4/task.html#search)** search parameters
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
-   - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][code]`)
+   - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][value]`)
    - including support for **[`multipleOr`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)** search on `status`
 
-    `GET [base]/Task?requester={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?requester.identifier=[system|][code]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Task?requester={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?requester:PractitionerRole.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
       1. GET [base]/Task?requester=5678&status=completed
-      1. GET [base]/Task?requester.identifier=http://ns.electronichealth.net.au/id/medicare-provider-number\|553255&status=completed
+      1. GET [base]/Task?requester:PractitionerRole.identifier=http://ns.electronichealth.net.au/id/medicare-provider-number\|553255&status=completed
       1. GET [base]/Task?requester=5678&status=accepted,in-progress&_include=Task:patient&_include=Task:requester&_include=Task:owner
 
     *Implementation Notes:* Fetches a bundle containing Task resources matching the requester and status ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference), [how to search by token](http://hl7.org/fhir/R4/search.html#token))

--- a/input/includes/task_notes.md
+++ b/input/includes/task_notes.md
@@ -38,7 +38,7 @@ The following search parameters and search parameter combinations are supported.
    - including support for **[`multipleAnd`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)** search on `_lastUpdated`
    - including support for search comparators `gt`, `lt`, `ge`, `le` on `_lastUpdated`
 
-    `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner={Type/}[id]` or optionally `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner:Organization.identifier=[system|][value]`
+    `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner={Type/}[id]` or optionally `GET [base]/Task?_lastUpdated={gt|lt|ge|le}[date]&status={system|}[code]&owner.identifier=[system|][value]`
 
     Example:
     
@@ -94,7 +94,7 @@ The following search parameters and search parameter combinations are supported.
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
    - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][value]`)
 
-    `GET [base]/Task?owner={Type/}[id]` or optionally `GET [base]/Task?owner:Organization.identifier=[system|][value]`
+    `GET [base]/Task?owner={Type/}[id]` or optionally `GET [base]/Task?owner.identifier=[system|][value]`
 
     Example:
     
@@ -110,7 +110,7 @@ The following search parameters and search parameter combinations are supported.
    - including support for chained searching of owner canonical identifier `owner.identifier` (e.g. `owner.identifier=[system|][value]`)
    - including support for **[`multipleOr`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)** search on `status`
 
-    `GET [base]/Task?owner={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?owner:Organization.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Task?owner={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?owner.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -159,7 +159,7 @@ The following search parameters and search parameter combinations are supported.
    - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `Task:focus`, `Task:owner`, `Task:patient`, and `Task:requester`
    - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][value]`)
 
-    `GET [base]/Task?requester={Type/}[id]` or optionally `GET [base]/Task?requester:PractitionerRole.identifier=[system|][value]`
+    `GET [base]/Task?requester={Type/}[id]` or optionally `GET [base]/Task?requester.identifier=[system|][value]`
 
     Example:
     
@@ -175,7 +175,7 @@ The following search parameters and search parameter combinations are supported.
    - including support for chained searching of requester canonical identifier `requester.identifier` (e.g. `requester.identifier=[system|][value]`)
    - including support for **[`multipleOr`](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)** search on `status`
 
-    `GET [base]/Task?requester={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?requester:PractitionerRole.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Task?requester={Type/}[id]&status={system|}[code]{,{system|}[code],...}` or optionally `GET [base]/Task?requester.identifier=[system|][value]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     


### PR DESCRIPTION
[FHIR-52290](https://jira.hl7.org/browse/FHIR-52290)
* For Task chained search examples for owner, patient and requester, fix informative example queries to include resource qualifier as per https://hl7.org/fhir/2015May/search.html#2.1.1.3.12

[FHIR-51917](https://jira.hl7.org/browse/FHIR-51917)
* Change instances of 'groupIdentifier' to 'group-identifier'
* Noting there is an additional comment in this TC: "Also, it would be great to have an example of an ABN or HPI-O scoped group-identifier". Existing examples contain HPI-O scoped groupIdentifiers. No change.