### PR TITLE
Correct default obligations; add _include=ServiceRequest:supporting-info to examples (FHIR-53097, FHIR-53090)

### DIFF
--- a/input/fsh/au-erequesting-communicationrequest.fsh
+++ b/input/fsh/au-erequesting-communicationrequest.fsh
@@ -129,7 +129,7 @@ Description: "This profile sets minimum expectations for CommunicationRequest re
   * ^short = "Organisation sending the communication"
 
 * sender ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[actor].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-placer"
-* sender ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[code].valueCode = #SHALL:populate
+* sender ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[code].valueCode = #SHALL:populate-if-known
 * sender ^extension[http://hl7.org/fhir/StructureDefinition/obligation][1].extension[actor].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-filler"
 * sender ^extension[http://hl7.org/fhir/StructureDefinition/obligation][1].extension[code].valueCode = #SHALL:handle
 * sender ^extension[http://hl7.org/fhir/StructureDefinition/obligation][2].extension[actor].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-server"

--- a/input/fsh/au-erequesting-diagnosticrequest.fsh
+++ b/input/fsh/au-erequesting-diagnosticrequest.fsh
@@ -209,7 +209,7 @@ Description: "This profile sets minimum expectations for a ServiceRequest resour
 * encounter 1..1 MS
 * encounter only Reference(AUCoreEncounter)
 * encounter.reference 1..1
-* encounter ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[code].valueCode = #SHALL:populate-if-known
+* encounter ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[code].valueCode = #SHALL:populate
 * encounter ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[actor][0].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-placer"
 * encounter ^extension[http://hl7.org/fhir/StructureDefinition/obligation][1].extension[code].valueCode = #SHALL:handle
 * encounter ^extension[http://hl7.org/fhir/StructureDefinition/obligation][1].extension[actor].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-filler"

--- a/input/includes/servicerequest_notes.md
+++ b/input/includes/servicerequest_notes.md
@@ -30,7 +30,7 @@ The following search parameters and search parameter combinations are supported.
 
 
 1. **[`supporting-info`](https://build.fhir.org/ig/hl7au/au-fhir-base/SearchParameter-servicerequest-supporting-info.html)** search parameter
-   - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `ServiceRequest:patient`, `ServiceRequest:requester`, `ServiceRequest:encounter`
+   - including support for these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `ServiceRequest:patient`, `ServiceRequest:requester`, `ServiceRequest:encounter`, `ServiceRequest:supporting-info`
 
     `GET [base]/ServiceRequest?supporting-info={Type/}[id]`
 
@@ -38,6 +38,6 @@ The following search parameters and search parameter combinations are supported.
     
       1. GET [base]/ServiceRequest?supporting-info=9876
       1. GET [base]/ServiceRequest?supporting-info=Observation/9876
-      1. GET [base]/ServiceRequest?supporting-info=9876&_include=ServiceRequest:patient&_include=ServiceRequest:requester&_include=ServiceRequest:encounter
+      1. GET [base]/ServiceRequest?supporting-info=9876&_include=ServiceRequest:patient&_include=ServiceRequest:requester&_include=ServiceRequest:encounter&_include=ServiceRequest:supporting-info
 
     *Implementation Notes:* Fetches a bundle of all ServiceRequest resources matching the supporting-info ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference))


### PR DESCRIPTION
Fix for [FHIR-53090](https://jira.hl7.org/browse/FHIR-53090)
* AU eRequesting Diagnostic Request - ServiceRequest.encounter: change Placer obligation from populate-if-known to populate.
* AU eRequesting CommunicationRequest - CommunicationRequest.sender: change Placer obligation from populate to populate-if-known.

Fix for [FHIR-53097](https://jira.hl7.org/browse/FHIR-53097)
* add _include=ServiceRequest:supporting-info to supporting-info parameter section, add to example