### PR TITLE
Add fragment for extensions parameter (HL7 AU FHIR IG standard)

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -57,6 +57,7 @@ The following technical aspects were not considered priority for the scope of Re
 ### Dependencies
 
 {% include dependency-table.xhtml %}
+{% include expansion-params.xhtml %}
 
 ### AU eRequesting FHIR RESTful Interactions
 


### PR DESCRIPTION
This PR implements the agreed HL7 AU convention to include expansion-params.xhtml fragment so readers can see any significant parameters such as system-version for SNOMED edition. 

This aligns all HL7 AU IGs and addresses new IG Publisher 2.0.23+ warning about documenting expansion parameters.

For more information, see Zulip chat: https://chat.fhir.org/#narrow/channel/179294-committers.2Fannounce/topic/Tracked.20Fragment.20for.20Expansion.20Parameters/with/547622199 