### PR TITLE
Guidance fixes: FHIR-51919, FHIR-52338, FHIR-52405

### DIFF
--- a/input/fsh/au-erequesting-communicationrequest-patient.fsh
+++ b/input/fsh/au-erequesting-communicationrequest-patient.fsh
@@ -12,8 +12,6 @@ Description: "This profile sets the minimum expectations for a CommunicationRequ
 * category from AUeRequestingCommunicationRequestPatientCategory (required)
 
 * doNotPerform 0..1 MS
-  * ^short = "Set to true when SMS or email communication with the patient is not to be performed"
-
 * doNotPerform ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[actor].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-placer"
 * doNotPerform ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[code].valueCode = #SHALL:populate-if-known
 * doNotPerform ^extension[http://hl7.org/fhir/StructureDefinition/obligation][1].extension[actor].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-filler"

--- a/input/pagecontent/StructureDefinition-au-erequesting-clinicalcontext-documentreference-intro.md
+++ b/input/pagecontent/StructureDefinition-au-erequesting-clinicalcontext-documentreference-intro.md
@@ -1,7 +1,2 @@
 ### Profile Specific Implementation Guidance
-- Clinical context is defined as narrative information providing an overview of the individual's current clinical situation associated with a requested service.
-- This profile constrains `DocumentReference.content.attachment` to support narrative text only, ensuring consistency with the definition of clinical context from [AUeReqDI](auereqdi.html). To support this, the following constraints apply:
-    - `DocumentReference.content.attachment` is mandatory to ensure that clinical context is always provided.
-    - `DocumentReference.content.attachment.contentType `is constrained to `text/plain`, limiting the representation to plain text narrative. This ensures that the content is both human-readable and interoperable across systems without additional rendering or format handling. Other formats such as PDF, DOC, DOCX, or HTML are not permitted.
-    - `DocumentReference.content.attachment.data` must be provided inline using base64 encoding. This ensures that the narrative is included in the resource, avoiding dependencies on external systems or links.
-- These constraints are designed to ensure that clinical context is accessible, clearly represented, and consistently exchanged as part of AU eRequesting workflows. 
+- Clinical context is to be implemented as unformatted text narrative representing the broader clinical background or circumstances related to a request, not general comments or administrative notes.

--- a/input/pagecontent/StructureDefinition-au-erequesting-task-intro.md
+++ b/input/pagecontent/StructureDefinition-au-erequesting-task-intro.md
@@ -1,6 +1,7 @@
 
 ### Profile Specific Implementation Guidance
 - This abstract profile provides a shared base that is common across tasks. It is not intended for direct implementation. Where a task profile is defined for a specific purpose that profile **SHALL** be used:
-  - group tasks **SHALL** use [AU eRequesting Task Group](StructureDefinition-au-erequesting-task-group.html) profile
-  - diagnostic request tasks **SHALL** use [AU eRequesting Task Diagnostic Request](StructureDefinition-au-erequesting-task-diagnosticrequest.html) profile 
+  - Group tasks **SHALL** use [AU eRequesting Task Group](StructureDefinition-au-erequesting-task-group.html) profile
+  - Diagnostic request tasks **SHALL** use [AU eRequesting Task Diagnostic Request](StructureDefinition-au-erequesting-task-diagnosticrequest.html) profile
+  - Communication request tasks **SHALL** use [AU eRequesting Task Communication Request](StructureDefinition-au-erequesting-task-communicationrequest.html) profile
 - See the [AU eRequesting Workflow Guidance](workflow.html) page for guidance on managing workflow states in AU eRequesting.


### PR DESCRIPTION
Fix for [FHIR-52405](https://jira.hl7.org/browse/FHIR-52405)
* remove short for doNotPerform in AU eRequesting CommunicationRequest Patient

Fix for [FHIR-52338](https://jira.hl7.org/browse/FHIR-52338)
* add guidance line to AU eRequesting Task as per ticket

Fix for [FHIR-51919](https://jira.hl7.org/browse/FHIR-51919)
* for AU eReq Clinical Context DocumentReference profile, remove existing Profile Specific Implementation Guidance.
* replace with single sentence as per ticket