### PR TITLE
QA fix ServiceRequest.requisition & Task.groupIdentifier - required pattern to 'type', remove max cardinality on coding

### DIFF
--- a/input/fsh/au-erequesting-diagnosticrequest.fsh
+++ b/input/fsh/au-erequesting-diagnosticrequest.fsh
@@ -147,9 +147,7 @@ Description: "This profile sets minimum expectations for a ServiceRequest resour
 
 * requisition 1..1 MS
 * requisition only $AULocalOrderIdentifier
-* requisition.type 
-  * coding 1..1    
-  * coding = $v2-0203#PGN
+* requisition.type = $v2-0203#PGN
 * requisition ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[code].valueCode = #SHALL:populate
 * requisition ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[actor][0].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-placer"
 * requisition ^extension[http://hl7.org/fhir/StructureDefinition/obligation][1].extension[code].valueCode = #SHALL:handle

--- a/input/fsh/au-erequesting-task.fsh
+++ b/input/fsh/au-erequesting-task.fsh
@@ -55,9 +55,7 @@ Description: "This profile sets minimum expectations for a Task resource that is
 
 * groupIdentifier 1..1 MS
 * groupIdentifier ^type.profile = $AULocalOrderIdentifier
-* groupIdentifier.type 
-  * coding 1..1    
-  * coding = $v2-0203#PGN
+* groupIdentifier.type = $v2-0203#PGN
 * groupIdentifier ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[actor][0].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-placer"
 * groupIdentifier ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[code].valueCode = #SHALL:populate
 * groupIdentifier ^extension[http://hl7.org/fhir/StructureDefinition/obligation][1].extension[actor].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-filler"


### PR DESCRIPTION
See issue outlined: https://github.com/hl7au/au-fhir-erequesting/issues/292.

QA Fixes:
* ServiceRequest.requisition - TDG agreement was a motion "to constrain the ServiceRequest.requisition element to the AU Local Order ID profile with identifier.type of PGN". See [here](https://confluence.hl7.org/spaces/HAFWG/pages/254640390/2024-06-25+AU+eRequesting+TDG+Agenda+Minutes). QA fix to correctly apply required pattern to ServiceRequest.requisition.type, and remove max cardinality of 1 from coding as per agreement. Noting no change to intent.
* Task.groupIdentifier - TDG agreement was "Motion to make Task.groupIdentifier a Must Support element with cardinality 1..1, type is AULocalOrderIdentifier with a fixed code 'PGN'." See [here](https://confluence.hl7.org/spaces/HAFWG/pages/256509723/2024-08-20+AU+eRequesting+TDG+Agenda+Minutes). QA fix to correctly apply required pattern to Task.groupIdentifier.type, and remove max cardinality of 1 from coding as per agreement. Noting no change to intent.