### PR TITLE
Add MS, obligations and "fulfill" as patternCodeableConcept to Task.code for all Task profiles (FHIR-53230)

### DIFF
--- a/input/examples/task-communicationrequest-urgent-results-to-provider.xml
+++ b/input/examples/task-communicationrequest-urgent-results-to-provider.xml
@@ -36,6 +36,12 @@
   <status value="requested"/>
   <intent value="order"/>
   <priority value="urgent"/>
+  <code>
+    <coding>
+      <system value="http://hl7.org/fhir/CodeSystem/task-code"/>
+      <code value="fulfill"/>
+    </coding>
+  </code>
   <focus>
     <reference value="CommunicationRequest/communicationrequest-urgent-results-to-provider"/>
   </focus>

--- a/input/fsh/au-erequesting-task.fsh
+++ b/input/fsh/au-erequesting-task.fsh
@@ -133,6 +133,19 @@ Description: "This profile sets minimum expectations for a Task resource that is
 * priority ^extension[http://hl7.org/fhir/StructureDefinition/obligation][4].extension[code].valueCode = #SHALL:no-error
 * priority ^extension[http://hl7.org/fhir/StructureDefinition/obligation][4].extension[actor][0].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-patient"
 
+* code 1..1 MS
+* code = $taskcode#fulfill
+* code ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[actor][0].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-placer"
+* code ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[code].valueCode = #SHALL:populate
+* code ^extension[http://hl7.org/fhir/StructureDefinition/obligation][1].extension[actor].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-filler"
+* code ^extension[http://hl7.org/fhir/StructureDefinition/obligation][1].extension[code].valueCode = #SHALL:handle
+* code ^extension[http://hl7.org/fhir/StructureDefinition/obligation][2].extension[actor].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-server"
+* code ^extension[http://hl7.org/fhir/StructureDefinition/obligation][2].extension[code].valueCode = #SHALL:handle
+* code ^extension[http://hl7.org/fhir/StructureDefinition/obligation][3].extension[actor].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-server"
+* code ^extension[http://hl7.org/fhir/StructureDefinition/obligation][3].extension[code].valueCode = #SHALL:able-to-populate
+* code ^extension[http://hl7.org/fhir/StructureDefinition/obligation][4].extension[actor][0].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-patient"
+* code ^extension[http://hl7.org/fhir/StructureDefinition/obligation][4].extension[code].valueCode = #SHALL:no-error
+
 * for 1..1 MS
 * for only Reference(AUeRequestingPatient)
 * for ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[actor][0].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-placer"

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -61,6 +61,13 @@ This change log documents the significant updates and resolutions implemented fr
   - changed Task.for type from AU Core Patient to AU eRequesting Patient [FHIR-51874](https://jira.hl7.org/browse/FHIR-51874)
   - changed Task.owner type from AU Core Organization to AU eRequesting Organization [FHIR-51874](https://jira.hl7.org/browse/FHIR-51874)
   - changed Task.requester type from AU Core PractitionerRole to AU eRequesting PractitionerRole [FHIR-51874](https://jira.hl7.org/browse/FHIR-51874)
+  - added Must Support and TaskCode code "fulfill" as patternCodeableConcept to Task.code, and changed cardinality from 0..1 to 1..1 [FHIR-53230](https://jira.hl7.org/browse/FHIR-53230)
+- [AU eRequesting Task Communication Request](StructureDefinition-au-erequesting-task-communicationrequest.html):
+  - added Must Support and TaskCode code "fulfill" as patternCodeableConcept to Task.code, and changed cardinality from 0..1 to 1..1 [FHIR-53230](https://jira.hl7.org/browse/FHIR-53230)
+- [AU eRequesting Task Diagnostic Request](StructureDefinition-au-erequesting-task-diagnosticrequest.html):
+  - added Must Support and TaskCode code "fulfill" as patternCodeableConcept to Task.code, and changed cardinality from 0..1 to 1..1 [FHIR-53230](https://jira.hl7.org/browse/FHIR-53230)
+- [AU eRequesting Task Group](StructureDefinition-au-erequesting-task-group.html):
+  - added Must Support and TaskCode code "fulfill" as patternCodeableConcept to Task.code, and changed cardinality from 0..1 to 1..1 [FHIR-53230](https://jira.hl7.org/browse/FHIR-53230)
 - [AU eRequesting Placer CapabilityStatement](CapabilityStatement-au-erequesting-placer.html):
   - added support for transaction interaction as SHOULD [FHIR-52519](https://jira.hl7.org/browse/FHIR-52519)
   - added format support for json as SHOULD and format support for xml as MAY [FHIR-52288](https://jira.hl7.org/browse/FHIR-52288)


### PR DESCRIPTION
[FHIR-53230](https://jira.hl7.org/browse/FHIR-53230)
* Change Task.code to 1..1, MS with default obligations in Task abstract profile
* Apply required pattern for "fulfill"
* Add Task.code to Task CommReq example (already present in other Task examples)
* Change log entries for abstract and child profiles