### PR TITLE
ValueSets : Update uris and assign OID

### DIFF
--- a/input/fsh/au-erequesting-communicationrequest.fsh
+++ b/input/fsh/au-erequesting-communicationrequest.fsh
@@ -40,7 +40,7 @@ Description: "This profile sets minimum expectations for CommunicationRequest re
 * status ^extension[http://hl7.org/fhir/StructureDefinition/obligation][4].extension[code].valueCode = #SHALL:no-error  
   
 * category 1.. MS
-* category from http://hl7.org.au/fhir/ereq/ValueSet/au-erequesting-communicationrequest-category (extensible)
+* category from AUeRequestingCommunicationRequestCategory (extensible)
 * category ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[actor].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-placer"
 * category ^extension[http://hl7.org/fhir/StructureDefinition/obligation][0].extension[code].valueCode = #SHALL:populate
 * category ^extension[http://hl7.org/fhir/StructureDefinition/obligation][1].extension[actor].valueCanonical = "http://hl7.org.au/fhir/ereq/ActorDefinition/au-erequesting-actor-filler"

--- a/input/fsh/valuesets/au-erequesting-communicationrequest-category.fsh
+++ b/input/fsh/valuesets/au-erequesting-communicationrequest-category.fsh
@@ -3,6 +3,7 @@ Id: au-erequesting-communicationrequest-category
 Title: "AU eRequesting CommunicationRequest Category"
 Description: "Categories for a communication request used in the Australian eRequesting context."
 * ^meta.profile[+] = "https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"
+* ^url = "http://terminology.hl7.org.au/ValueSet/au-erequesting-communicationrequest-category"
 * ^version = "1.0.0"
 * ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 0
 * ^date = "2025-11-20"

--- a/input/fsh/valuesets/au-erequesting-communicationrequest-patient-medium.fsh
+++ b/input/fsh/valuesets/au-erequesting-communicationrequest-patient-medium.fsh
@@ -4,7 +4,10 @@ Title: "AU eRequesting CommunicationRequest Patient Medium"
 Description: "Medium values for patient communication used in the Australian eRequesting context."
 
 * ^meta.profile[+] = "https://healthterminologies.gov.au/fhir/StructureDefinition/composed-value-set-4"
+* ^url = "http://terminology.hl7.org.au/ValueSet/au-erequesting-communicationrequest-patientmedium"
 * ^version = "1.0.0"
+* ^identifier.value = "urn:oid:2.16.840.1.113883.2.3.4.2.4.41"
+* ^identifier.system = $oid
 * ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm].valueInteger = 1
 * ^date = "2025-02-04"
 * ^publisher = "HL7 Australia"

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -22,6 +22,7 @@ This change log documents the significant updates and resolutions implemented fr
   - added CommunicationRequest.category value set binding to AU eRequesting CommunicationRequest Category (extensible) and removed Must Support and obligations from CommunicationRequest.reasonCode [AU eReq: FHIR-52409](https://jira.hl7.org/browse/FHIR-52409)
 - [AU eRequesting CommunicationRequest Category](ValueSet-au-erequesting-communicationrequest-category.html):
   - added new value set [AU eReq: FHIR-52409](https://jira.hl7.org/browse/FHIR-52409)
+  - changed value set url from http://hl7.org.au/fhir/ereq/ValueSet/au-erequesting-communicationrequest-category to http://terminology.hl7.org.au/ValueSet/au-erequesting-communicationrequest-category [AU eReq: FHIR-53571](https://jira.hl7.org/browse/FHIR-53571)
 - [AU eRequesting CommunicationRequest CopyTo](StructureDefinition-au-erequesting-communicationrequest-copyto.html):
   - changed CommunicationRequest.requester type from AU Core PractitionerRole to AU eRequesting PractitionerRole [AU eReq: FHIR-51874](https://jira.hl7.org/browse/FHIR-51874)
   - added CommunicationRequest.category value set binding to AU eRequesting CommunicationRequest Category (extensible) and changed patternCodeableConcept from "notification" to "copyto-reports" [AU eReq: FHIR-52409](https://jira.hl7.org/browse/FHIR-52409)
@@ -35,6 +36,8 @@ This change log documents the significant updates and resolutions implemented fr
   - removed Must Support, obligations and required pattern from CommunicationRequest.reasonCode [AU eReq: FHIR-52409](https://jira.hl7.org/browse/FHIR-52409)
 - [AU eRequesting CommunicationRequest Patient Category](ValueSet-au-erequesting-communicationrequest-patientcategory.html):
   - deprecated value set [AU eReq: FHIR-52409](https://jira.hl7.org/browse/FHIR-52409)
+- [AU eRequesting CommunicationRequest Patient Medium ](ValueSet-au-erequesting-communicationrequest-patientmedium.html):
+  - changed value set url from http://hl7.org.au/fhir/ereq/ValueSet/au-erequesting-communicationrequest-patientmedium to http://terminology.hl7.org.au/ValueSet/au-erequesting-communicationrequest-patientmedium [AU eReq: FHIR-53571](https://jira.hl7.org/browse/FHIR-53571)
 - [AU eRequesting CommunicationRequest Reason](ValueSet-au-erequesting-communicationrequest-reason.html):
   - deprecated value set [AU eReq: FHIR-52409](https://jira.hl7.org/browse/FHIR-52409)
 - [AU eRequesting CommunicationRequest Urgent Provider](StructureDefinition-au-erequesting-communicationrequest-urgentprovider.html):

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -97,6 +97,8 @@ parameters:  # see https://confluence.hl7.org/display/FHIR/Implementation+Guide+
     - input/resources
   special-url:
     - https://ranzcr.com/fhir/ValueSet/radiology-referral-1
+    - http://terminology.hl7.org.au/ValueSet/au-erequesting-communicationrequest-category
+    - http://terminology.hl7.org.au/ValueSet/au-erequesting-communicationrequest-patientmedium
     - http://terminology.hl7.org.au/ValueSet/communicationrequest-category
     - http://terminology.hl7.org.au/ValueSet/au-erequesting-coverage-type
     - http://terminology.hl7.org.au/ValueSet/au-erequesting-request-status


### PR DESCRIPTION
Fix for [FHIR-53571](https://jira.hl7.org/browse/FHIR-53571)

- Change valueset.url  in AU eRequesting CommunicationRequest Patient Medium from http://hl7.org.au/fhir/ereq/ValueSet/au-erequesting-communicationrequest-patientmedium to http://terminology.hl7.org.au/ValueSet/au-erequesting-communicationrequest-patientmedium
-  Change valueset.url in AU eRequesting CommunicationRequest Category from http://hl7.org.au/fhir/ereq/ValueSet/au-erequesting-communicationrequest-category to http://terminology.hl7.org.au/ValueSet/au-erequesting-communicationrequest-category
- update binding in AU eRequesting CommunicationRequest on CommunicationRequest.category to AUeRequestingCommunicationRequestCategory
- Add OID 2.16.840.1.113883.2.3.4.2.4.41 to AU eRequesting CommunicationRequest Patient Medium value set
- added change log entry
- QA fix to change log entry moved cardinality change on CommunicationRequest.groupIdentifier.type.coding to correct place