### PR TITLE
Add referenced AU Core profiles back to CapabilityStatements (FHIR-54089)

### DIFF
--- a/input/resources/au-erequesting-filler.xml
+++ b/input/resources/au-erequesting-filler.xml
@@ -252,7 +252,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="The AU eRequesting Filler actor **SHALL** support the Encounter resource, the AU eRequesting profile, and the conformance expectations for the Encounter resource."/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-encounter">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="The AU eRequesting Filler actor **SHALL** support the Encounter resource, the AU eRequesting profile, the AU Core profile, and the conformance expectations for the Encounter resource."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHOULD"/>
@@ -374,7 +379,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="The AU eRequesting Filler actor **SHALL** support the Organization resource, the AU eRequesting profile, and the conformance expectations for the Organization resource."/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-organization">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="The AU eRequesting Filler actor **SHALL** support the Organization resource, the AU eRequesting profile, the AU Core profile, and the conformance expectations for the Organization resource."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHOULD"/>
@@ -421,12 +431,17 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
       <supportedProfile value="http://hl7.org/fhir/uv/ips/StructureDefinition/Patient-uv-ips">
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="The AU eRequesting Filler actor **SHALL** support the Patient resource, the AU eRequesting profile, the Patient (IPS) profile and the conformance expectations for the Patient resource."/>
+      <documentation value="The AU eRequesting Filler actor **SHALL** support the Patient resource, the AU eRequesting profile, the AU Core profile, the Patient (IPS) profile and the conformance expectations for the Patient resource."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHOULD"/>
@@ -473,7 +488,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="The AU eRequesting Filler actor **SHALL** support the Practitioner resource, the AU eRequesting profile, and the conformance expectations for the Practitioner resource."/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitioner">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="The AU eRequesting Filler actor **SHALL** support the Practitioner resource, the AU eRequesting profile, the AU Core profile, and the conformance expectations for the Practitioner resource."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHOULD"/>
@@ -520,7 +540,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="The AU eRequesting Filler actor **SHALL** support the PractitionerRole resource, the AU eRequesting profile, and the conformance expectations for the PractitionerRole resource.&#xa;&#xa;The AU eRequesting Filler actor **MAY** support the `_include` parameter for `PractitionerRole:practitioner` and `PractitionerRole:organization`"/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitionerrole">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="The AU eRequesting Filler actor **SHALL** support the PractitionerRole resource, the AU eRequesting profile, the AU Core profile, and the conformance expectations for the PractitionerRole resource.&#xa;&#xa;The AU eRequesting Filler actor **MAY** support the `_include` parameter for `PractitionerRole:practitioner` and `PractitionerRole:organization`"/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHOULD"/>

--- a/input/resources/au-erequesting-patient.xml
+++ b/input/resources/au-erequesting-patient.xml
@@ -252,7 +252,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="If the AU eRequesting Patient actor supports the Encounter resource, the AU eRequesting Patient actor **SHALL** support the AU eRequesting Encounter profile, and the conformance expectations for the Encounter resource."/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-encounter">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="If the AU eRequesting Patient actor supports the Encounter resource, the AU eRequesting Patient actor **SHALL** support the AU eRequesting profile, the AU Core profile, and the conformance expectations for the Encounter resource."/>
        <interaction>
 	      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 	        <valueCode value="SHOULD"/>
@@ -374,7 +379,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="If the AU eRequesting Patient actor supports the Organization resource, the AU eRequesting Patient actor **SHALL** support the AU eRequesting Organization profile, and the conformance expectations for the Organization resource."/>
+        <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-organization">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="If the AU eRequesting Patient actor supports the Organization resource, the AU eRequesting Patient actor **SHALL** support the AU eRequesting profile, the AU Core profile, and the conformance expectations for the Organization resource."/>
        <interaction>
 	      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 	        <valueCode value="SHOULD"/>
@@ -426,7 +436,12 @@
           <valueCode value="SHALL"/>
         </extension>
 	    </supportedProfile>
-      <documentation value="If the AU eRequesting Patient actor supports the Patient resource, the AU eRequesting Patient profile, the Patient (IPS) profile, and the conformance expectations for the Patient resource **SHALL** be supported."/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+	    </supportedProfile>
+      <documentation value="If the AU eRequesting Patient actor supports the Patient resource, the AU eRequesting Patient profile, the AU Core profile, the Patient (IPS) profile, and the conformance expectations for the Patient resource **SHALL** be supported."/>
       <interaction>
 	      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 	        <valueCode value="SHOULD"/>
@@ -473,7 +488,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="If the AU eRequesting Patient actor supports the Practitioner resource, AU eRequesting Patient actor **SHALL** support the AU eRequesting Practitioner profile, and the conformance expectations for the Practitioner resource."/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitioner">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="If the AU eRequesting Patient actor supports the Practitioner resource, AU eRequesting Patient actor **SHALL** support the AU eRequesting profile, the AU Core profile, and the conformance expectations for the Practitioner resource."/>
       <interaction>
 	      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 	        <valueCode value="SHOULD"/>
@@ -520,7 +540,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="If the AU eRequesting Patient actor supports the PractitionerRole resource, the AU eRequesting Patient actor **SHALL** support the AU eRequesting PractitionerRole profile, and the conformance expectations for the PractitionerRole resource.&#xa;&#xa;The AU eRequesting Patient actor **MAY** support the `_include` parameter for `PractitionerRole:practitioner` and `PractitionerRole:organization`"/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitionerrole">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="If the AU eRequesting Patient actor supports the PractitionerRole resource, the AU eRequesting Patient actor **SHALL** support the AU eRequesting profile, the AU Core profile, and the conformance expectations for the PractitionerRole resource.&#xa;&#xa;The AU eRequesting Patient actor **MAY** support the `_include` parameter for `PractitionerRole:practitioner` and `PractitionerRole:organization`"/>
       <interaction>
 	      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 	        <valueCode value="SHOULD"/>

--- a/input/resources/au-erequesting-placer.xml
+++ b/input/resources/au-erequesting-placer.xml
@@ -312,7 +312,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="The AU eRequesting Placer actor **SHALL** support the Encounter resource, the AU eRequesting profile, and the conformance expectations for the Encounter resource."/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-encounter">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="The AU eRequesting Placer actor **SHALL** support the Encounter resource, the AU eRequesting profile, the AU Core profile, and the conformance expectations for the Encounter resource."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHOULD"/>
@@ -470,7 +475,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="The AU eRequesting Placer actor **SHALL** support the Organization resource, the AU eRequesting profile, and the conformance expectations for the Organization resource."/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-organization">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="The AU eRequesting Placer actor **SHALL** support the Organization resource, the AU eRequesting profile, the AU Core profile, and the conformance expectations for the Organization resource."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHOULD"/>
@@ -529,12 +539,17 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient">
+	         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+	           <valueCode value="SHALL"/>
+	         </extension>
+	    </supportedProfile>
       <supportedProfile value="http://hl7.org/fhir/uv/ips/StructureDefinition/Patient-uv-ips">
 	         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 	           <valueCode value="SHALL"/>
 	         </extension>
 	    </supportedProfile>
-      <documentation value="The AU eRequesting Placer actor **SHALL** support the Patient resource, the AU eRequesting profile, the Patient (IPS) profile and the conformance expectations for the Patient resource."/>
+      <documentation value="The AU eRequesting Placer actor **SHALL** support the Patient resource, the AU eRequesting profile, the AU Core profile, the Patient (IPS) profile and the conformance expectations for the Patient resource."/>
       <interaction>
           <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
             <valueCode value="SHOULD"/>
@@ -593,7 +608,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="The AU eRequesting Placer actor **SHALL** support the Practitioner resource, the AU eRequesting profile, and the conformance expectations for the Practitioner resource."/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitioner">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="The AU eRequesting Placer actor **SHALL** support the Practitioner resource, the AU eRequesting profile, the AU Core profile, and the conformance expectations for the Practitioner resource."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHOULD"/>
@@ -652,7 +672,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="The AU eRequesting Placer actor **SHALL** support the PractitionerRole resource, the AU eRequesting profile, and the conformance expectations for the PractitionerRole resource.&#xa;&#xa;The AU eRequesting Placer actor **MAY** support the `_include` parameter for `PractitionerRole:practitioner` and `PractitionerRole:organization`."/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitionerrole">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="The AU eRequesting Placer actor **SHALL** support the PractitionerRole resource, the AU eRequesting profile, the AU Core profile, and the conformance expectations for the PractitionerRole resource.&#xa;&#xa;The AU eRequesting Placer actor **MAY** support the `_include` parameter for `PractitionerRole:practitioner` and `PractitionerRole:organization`."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHOULD"/>

--- a/input/resources/au-erequesting-server.xml
+++ b/input/resources/au-erequesting-server.xml
@@ -306,7 +306,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="The AU eRequesting Server actor **SHALL** support the Encounter resource, the AU eRequesting profile, and the conformance expectations for the Encounter resource."/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-encounter">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="The AU eRequesting Server actor **SHALL** support the Encounter resource, the AU eRequesting profile, the AU Core profile, and the conformance expectations for the Encounter resource."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHALL"/>
@@ -464,7 +469,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="The AU eRequesting Server actor **SHALL** support the Organization resource, the AU eRequesting profile, and the conformance expectations for the Organization resource."/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-organization">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="The AU eRequesting Server actor **SHALL** support the Organization resource, the AU eRequesting profile, the AU Core profile, and the conformance expectations for the Organization resource."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHALL"/>
@@ -523,12 +533,17 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+	    </supportedProfile>
       <supportedProfile value="http://hl7.org/fhir/uv/ips/StructureDefinition/Patient-uv-ips">
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHALL"/>
         </extension>
 	    </supportedProfile>
-      <documentation value="The AU eRequesting Server actor **SHALL** support the Patient resource, the AU eRequesting profile, the Patient (IPS) profile, and the conformance expectations for the Patient resource."/>
+      <documentation value="The AU eRequesting Server actor **SHALL** support the Patient resource, the AU eRequesting profile, the AU Core profile, the Patient (IPS) profile, and the conformance expectations for the Patient resource."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHALL"/>
@@ -587,8 +602,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="The AU eRequesting Server actor **SHALL** support the Practitioner resource, the AU eRequesting
-       profile, and the conformance expectations for the Practitioner resource."/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitioner">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="The AU eRequesting Server actor **SHALL** support the Practitioner resource, the AU eRequesting profile, the AU Core profile, and the conformance expectations for the Practitioner resource."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHALL"/>
@@ -647,7 +666,12 @@
           <valueCode value="SHALL"/>
         </extension>
       </supportedProfile>
-      <documentation value="The AU eRequesting Server actor **SHALL** support the PractitionerRole resource, the AU eRequesting profile, and the conformance expectations for the PractitionerRole resource.&#xa;&#xa;The AU eRequesting Server actor **SHALL** support the `_include` parameter for `PractitionerRole:practitioner` and `PractitionerRole:organization`."/>
+      <supportedProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitionerrole">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="The AU eRequesting Server actor **SHALL** support the PractitionerRole resource, the AU eRequesting profile, the AU Core profile, and the conformance expectations for the PractitionerRole resource.&#xa;&#xa;The AU eRequesting Server actor **SHALL** support the `_include` parameter for `PractitionerRole:practitioner` and `PractitionerRole:organization`."/>
       <interaction>
         <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
           <valueCode value="SHALL"/>


### PR DESCRIPTION
[FHIR-54089](https://jira.hl7.org/browse/FHIR-54089)
Added the following back to CapStats:

- AU Core Encounter
- AU Core Patient
- AU Core Practitioner
- AU Core PractitionerRole
- AU Core Organization