### PR TITLE
QA: remove path-pages causing duplication in qa.html

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -91,10 +91,7 @@ parameters:  # see https://confluence.hl7.org/display/FHIR/Implementation+Guide+
     input/resources
     fsh-generated/resources
   path-pages:
-    - input/pagecontent
-    - input/intro-notes
     - fsh-generated/includes
-    - input/resources
   special-url:
     - https://ranzcr.com/fhir/ValueSet/radiology-referral-1
     - http://terminology.hl7.org.au/ValueSet/au-erequesting-communicationrequest-category


### PR DESCRIPTION
Removed the following path-pages from sushi-config (no longer required as IG published auto-detects files):
    - input/pagecontent
    - input/intro-notes
    - input/resources
Confirmed removal of duplicated qa.html entries.

Please confirm no changes to IG.