### PR TITLE
Removed IG version comparison with previous versions for Release 1

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -120,7 +120,7 @@ parameters:  # see https://confluence.hl7.org/display/FHIR/Implementation+Guide+
   excludettl: false
   excludemap: true
   shownav: false
- 
+  version-comparison: n/a
   # generate: #what does this do - todo: remove and see4
   #   - xml
   #   - json


### PR DESCRIPTION
AU eRequesting TDG co-chairs have agreed to remove IG version comparison for Release 1 of AU eRequesting